### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 Model Context Protocol (MCP) server for integrating Redash with AI assistants like Claude.
 
+<a href="https://glama.ai/mcp/servers/j9bl90s3tw">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/j9bl90s3tw/badge" alt="Redash Server MCP server" />
+</a>
+
 ## Features
 
 - Connect to Redash instances via the Redash API


### PR DESCRIPTION
This PR adds a badge for the [Redash MCP Server](https://glama.ai/mcp/servers/j9bl90s3tw) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/j9bl90s3tw">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/j9bl90s3tw/badge" alt="Redash Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.