### PR TITLE
Fix: Expose error details from executeQuery and pollQueryResults (#7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suthio/redash-mcp",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suthio/redash-mcp",
-      "version": "1.0.0",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",
@@ -24,6 +24,9 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.2.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@suthio/redash-mcp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "MCP server for Redash integration",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Enhanced error handling in `executeQuery` and `pollQueryResults` methods to expose detailed error information
- Replaced generic error messages with specific details including status codes and API response data
- Improved TypeScript typing by using `AxiosError` instead of `any`

## Motivation
Fixes #7 - When executeQuery fails, the underlying error message wasn't being propagated back to the Agent, causing repeated troubleshooting loops.

## Changes
- Import `AxiosError` type from axios for proper error typing
- Enhanced error handling in both methods to:
  - Capture and propagate detailed API error information
  - Include HTTP status codes in error messages
  - Preserve error response data from Redash API
  - Handle both axios and non-axios errors appropriately
- Bumped version to 0.0.3

## Test plan
- [x] Build passes without TypeScript errors
- [x] Error messages now include detailed information when API calls fail
- [x] Existing functionality remains unchanged
