### PR TITLE
feat: Add tagpr for automated version management and npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+name: Release and Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Build
+        run: npm run build
+        
+      - name: Test
+        run: npm test
+        
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,31 @@
+name: tagpr
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Run tagpr
+        uses: Songmu/tagpr@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,48 @@
+# Configuration for tagpr
+# See: https://github.com/Songmu/tagpr
+
+# The version file path
+versionFile = "package.json"
+
+# The release branch name
+releaseBranch = "main"
+
+# The tag prefix
+tagPrefix = "v"
+
+# Create major version tag (e.g., v1, v2)
+majorVersionTag = false
+
+# Create a release PR
+createReleasePR = true
+
+# Automatically merge the release PR
+autoMergeReleasePR = false
+
+# Use the default PR title
+useDefaultPRTitle = true
+
+# The PR title format
+prTitle = "Prepare for v{{ .Version }}"
+
+# The release commit message format
+releaseCommit = "release v{{ .Version }}"
+
+# Include the changelog in the release body
+includeChangelog = true
+
+# Automatically push the tag
+pushTag = true
+
+# Create a GitHub release
+createRelease = true
+
+# Release title format
+releaseTitle = "v{{ .Version }}"
+
+# Release body template
+releaseBody = |
+  ## What's Changed
+  {{ .Changelog }}
+  
+  **Full Changelog**: https://github.com/suthio/redash-mcp/compare/{{ .PreviousTag }}...{{ .CurrentTag }}


### PR DESCRIPTION
## Summary
- Add tagpr configuration for automated version management
- Configure GitHub Actions workflows for automated releases
- Enable automatic npm publishing on tag creation

## Changes
- **`.tagpr`**: Configuration file for tagpr with release settings
- **`.github/workflows/tagpr.yml`**: Workflow that runs on main branch pushes to create version update PRs
- **`.github/workflows/release.yml`**: Workflow that publishes to npm when tags are created

## How it works
1. When code is pushed to main, tagpr creates a PR with version updates
2. Merging the PR creates a git tag and GitHub release
3. Tag creation triggers npm publish workflow

## Required Setup
Before merging, please add the `NPM_TOKEN` secret to the repository:
1. Generate an automation token at https://www.npmjs.com/
2. Add it as `NPM_TOKEN` in Settings → Secrets and variables → Actions

## Test plan
- [ ] Verify `.tagpr` configuration is correct
- [ ] Check GitHub Actions workflows syntax
- [ ] Confirm NPM_TOKEN secret is added before first release

🤖 Generated with [Claude Code](https://claude.ai/code)