### PR TITLE
Add Visualization Management Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ Add the following configuration (edit paths as needed):
 - `get-dashboard`: Get dashboard details and visualizations 
 - `get-visualization`: Get details of a specific visualization
 
+### Visualization Management
+- `create-visualization`: Create a new visualization for a query
+- `update-visualization`: Update an existing visualization
+- `delete-visualization`: Delete a visualization
+
 ## Development
 
 Run in development mode:

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -52,6 +52,22 @@ export interface RedashVisualization {
   query_id: number;
 }
 
+// New interfaces for visualization creation and update
+export interface CreateVisualizationRequest {
+  query_id: number;
+  type: string;
+  name: string;
+  description?: string;
+  options: any;
+}
+
+export interface UpdateVisualizationRequest {
+  type?: string;
+  name?: string;
+  description?: string;
+  options?: any;
+}
+
 export interface RedashQueryResult {
   id: number;
   query_id: number;
@@ -433,6 +449,38 @@ export class RedashClient {
     } catch (error) {
       logger.error(`Error executing adhoc query: ${error}`);
       throw new Error(`Failed to execute adhoc query: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  // Create a new visualization
+  async createVisualization(data: CreateVisualizationRequest): Promise<RedashVisualization> {
+    try {
+      const response = await this.client.post('/api/visualizations', data);
+      return response.data;
+    } catch (error) {
+      console.error('Error creating visualization:', error);
+      throw new Error('Failed to create visualization');
+    }
+  }
+
+  // Update an existing visualization
+  async updateVisualization(visualizationId: number, data: UpdateVisualizationRequest): Promise<RedashVisualization> {
+    try {
+      const response = await this.client.post(`/api/visualizations/${visualizationId}`, data);
+      return response.data;
+    } catch (error) {
+      console.error(`Error updating visualization ${visualizationId}:`, error);
+      throw new Error(`Failed to update visualization ${visualizationId}`);
+    }
+  }
+
+  // Delete a visualization
+  async deleteVisualization(visualizationId: number): Promise<void> {
+    try {
+      await this.client.delete(`/api/visualizations/${visualizationId}`);
+    } catch (error) {
+      console.error(`Error deleting visualization ${visualizationId}:`, error);
+      throw new Error(`Failed to delete visualization ${visualizationId}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

This PR adds three new MCP tools for managing Redash visualizations:
- create_visualization - Create new visualizations for queries
- update_visualization - Update existing visualizations
- delete_visualization - Delete visualizations

## Changes

- Added new interfaces CreateVisualizationRequest and UpdateVisualizationRequest in redashClient.ts
- Implemented three new methods in RedashClient class for visualization operations
- Added corresponding MCP tool handlers in index.ts
- Updated README.md with documentation for the new tools

## Implementation Considerations

- Instance-agnostic descriptions: The tool descriptions intentionally avoid specifying exact visualization types or option  structures, as these vary between Redash instances and versions. Instead, they guide users to examine existing visualizations for reference, ensuring compatibility across different Redash deployments.

## Testing

All three tools have been tested with a real Redash instance:
- ✅ Created CHART and COUNTER visualizations successfully
- ✅ Updated visualization properties including complex options (multi-axis charts)
- ✅ Deleted visualizations with proper confirmation
