### PR TITLE
Support custom HTTP headers via REDASH_EXTRA_HEADERS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ REDASH_TIMEOUT=30000
 
 # Optional: Maximum number of results to return
 REDASH_MAX_RESULTS=1000
+
+# Optional: Extra HTTP headers (JSON or key=value;key2=value2)
+# Example for Cloudflare Access:
+# REDASH_EXTRA_HEADERS='{"CF-Access-Client-Id":"your_client_id","CF-Access-Client-Secret":"your_client_secret"}'

--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ The server requires the following environment variables:
 Optional variables:
 - `REDASH_TIMEOUT`: Timeout for API requests in milliseconds (default: 30000)
 - `REDASH_MAX_RESULTS`: Maximum number of results to return (default: 1000)
+- `REDASH_EXTRA_HEADERS`: Extra HTTP headers to include with every Redash request. Accepts either a JSON object string or a semicolon/comma-separated list of `key=value` pairs.
+
+Examples:
+
+JSON (recommended):
+```
+REDASH_EXTRA_HEADERS='{"CF-Access-Client-Id":"<client_id>","CF-Access-Client-Secret":"<client_secret>"}'
+```
+
+Key/value list:
+```
+REDASH_EXTRA_HEADERS=CF-Access-Client-Id=<client_id>;CF-Access-Client-Secret=<client_secret>
+```
+
+Notes:
+- The `Authorization` header is managed by the server (`Key <REDASH_API_KEY>`) and cannot be overridden.
+- All extra headers are added to every request made to Redash.
 
 ## Installation
 
@@ -50,6 +67,8 @@ Optional variables:
    ```
    REDASH_URL=https://your-redash-instance.com
    REDASH_API_KEY=your_api_key
+   # Optional: Cloudflare Access (or other gateway) headers
+   # REDASH_EXTRA_HEADERS='{"CF-Access-Client-Id":"<client_id>","CF-Access-Client-Secret":"<client_secret>"}'
    ```
 
 4. Build the project:


### PR DESCRIPTION
This PR adds generic support for attaching custom HTTP headers to all Redash API requests.

Summary
- Add `REDASH_EXTRA_HEADERS` env var (accepts JSON object string or key=value;key2=value2)
- Merge extra headers into Axios defaults for every request
- Prevent overriding the Authorization header for safety (still set to `Key <REDASH_API_KEY>`)
- Reduce header logging to names only to avoid leaking secrets
- Documentation updates (README, .env.example) including Cloudflare Access examples

Usage
- JSON (recommended)
  - `REDASH_EXTRA_HEADERS='{"CF-Access-Client-Id":"<client_id>","CF-Access-Client-Secret":"<client_secret>"}'`
- Key/value list
  - `REDASH_EXTRA_HEADERS=CF-Access-Client-Id=<client_id>;CF-Access-Client-Secret=<client_secret>`

Notes
- The `Authorization` header is intentionally preserved and cannot be overridden by `REDASH_EXTRA_HEADERS`.
- All extra headers are added to every request issued by the client.

Closes #22
