### PR TITLE
Add tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  unit-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test -- --coverage

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,10 @@ logs/
 
 # Testing
 coverage/
+test-results/
+playwright-report/
+e2e/screenshots/
+
+# LLM
+.gemini/
+.claude/

--- a/README.md
+++ b/README.md
@@ -140,6 +140,35 @@ Run in development mode:
 npm run dev
 ```
 
+## Testing
+
+### Unit Tests
+
+```bash
+npm test
+```
+
+### E2E Tests
+
+```bash
+npm run e2e:test
+```
+
+E2E tests use these default values (can be overridden with environment variables):
+- `REDASH_URL`: https://demo.redash.io
+- `REDASH_API_KEY`: test_api_key
+
+Override example:
+```bash
+REDASH_URL=https://your-instance.com REDASH_API_KEY=your_key npm run e2e:test
+```
+
+### Manual Testing
+
+```bash
+npm run inspector
+```
+
 ## Version History
 
 - v1.1.0: Added query management functionality (create, update, archive)

--- a/e2e/inspector-basic.spec.ts
+++ b/e2e/inspector-basic.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('MCP Inspector - Basic Tests', () => {
+  test('should load the inspector page', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for page to load
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check page title
+    const title = await page.title();
+    expect(title).toContain('MCP');
+
+    // Take screenshot
+    await page.screenshot({ path: 'e2e/screenshots/inspector-loaded.png', fullPage: true });
+  });
+
+  test('should display MCP Inspector UI', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Check for Inspector heading
+    const heading = page.getByText(/MCP Inspector/i);
+    await expect(heading).toBeVisible();
+
+    // Check for Connect button
+    const connectButton = page.getByRole('button', { name: /connect/i });
+    await expect(connectButton).toBeVisible();
+  });
+
+  test('should connect to MCP server', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Click Connect button
+    const connectButton = page.getByRole('button', { name: /connect/i });
+    await connectButton.click();
+
+    // Wait for "Connected" status to appear
+    await page.waitForSelector('text=/Connected/i', { timeout: 10000 });
+
+    // Wait a bit more for UI to stabilize
+    await page.waitForTimeout(2000);
+
+    // Verify connection status
+    const pageContent = await page.textContent('body');
+    expect(pageContent).toContain('Connected');
+
+    // Take screenshot after connection
+    await page.screenshot({ path: 'e2e/screenshots/inspector-connected.png', fullPage: true });
+  });
+
+  test('should show tools after connection', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Connect to server
+    const connectButton = page.getByRole('button', { name: /connect/i });
+    await connectButton.click();
+
+    // Wait for connection to be established
+    await page.waitForSelector('text=/Connected/i', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Verify we're connected
+    const statusCheck = await page.textContent('body');
+    if (!statusCheck?.includes('Connected')) {
+      throw new Error('Server not connected');
+    }
+
+    // Click on Tools tab
+    const toolsTab = page.getByRole('tab', { name: /tools/i });
+    await toolsTab.click();
+    await page.waitForTimeout(1000);
+
+    // Click "List Tools" button
+    const listToolsButton = page.getByRole('button', { name: /list tools/i });
+    await listToolsButton.click();
+    await page.waitForTimeout(1000);
+
+    // Check page content for tool names
+    const pageContent = await page.textContent('body');
+
+    // Verify some key tools are listed
+    expect(pageContent).toContain('list_queries');
+    expect(pageContent).toContain('get_query');
+    expect(pageContent).toContain('list_data_sources');
+  });
+
+  test('should show server information', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Connect to server
+    const connectButton = page.getByRole('button', { name: /connect/i });
+    await connectButton.click();
+
+    // Wait for connection
+    await page.waitForSelector('text=/Connected/i', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    const pageContent = await page.textContent('body');
+
+    // Verify connected
+    expect(pageContent).toContain('Connected');
+    // Server name should be visible
+    expect(pageContent).toContain('redash-mcp');
+  });
+
+  test('should list all 17 tools', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+
+    // Connect to server
+    const connectButton = page.getByRole('button', { name: /connect/i });
+    await connectButton.click();
+
+    // Wait for connection
+    await page.waitForSelector('text=/Connected/i', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Verify we're connected
+    const statusCheck = await page.textContent('body');
+    if (!statusCheck?.includes('Connected')) {
+      throw new Error('Server not connected');
+    }
+
+    // Click on Tools tab
+    const toolsTab = page.getByRole('tab', { name: /tools/i });
+    await toolsTab.click();
+    await page.waitForTimeout(1000);
+
+    // Click "List Tools" button
+    const listToolsButton = page.getByRole('button', { name: /list tools/i });
+    await listToolsButton.click();
+    await page.waitForTimeout(1000);
+
+    // Take screenshot of tools tab
+    await page.screenshot({ path: 'e2e/screenshots/inspector-tools-listed.png', fullPage: true });
+
+    const pageContent = await page.textContent('body');
+
+    const expectedTools = [
+      'list_queries',
+      'get_query',
+      'create_query',
+      'update_query',
+      'archive_query',
+      'list_data_sources',
+      'execute_query',
+      'execute_adhoc_query',
+      'get_query_results_csv',
+      'list_dashboards',
+      'get_dashboard',
+      'get_visualization',
+      'create_visualization',
+      'update_visualization',
+      'delete_visualization',
+      'get_schema',
+    ];
+
+    for (const tool of expectedTools) {
+      expect(pageContent).toContain(tool);
+    }
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,31 @@
+export default {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        useESM: true,
+      },
+    ],
+  },
+  testMatch: [
+    '**/__tests__/**/*.test.ts',
+    '**/?(*.)+(spec|test).ts'
+  ],
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/e2e/'
+  ],
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.d.ts',
+    '!src/cli.ts'
+  ],
+  coverageDirectory: 'coverage',
+  coverageReporters: ['text', 'lcov', 'html'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@suthio/redash-mcp",
-  "version": "0.0.3",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@suthio/redash-mcp",
-      "version": "0.0.3",
+      "version": "0.0.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.1.0",
@@ -18,6 +18,7 @@
         "redash-mcp": "dist/cli.js"
       },
       "devDependencies": {
+        "@playwright/test": "^1.57.0",
         "@types/jest": "^29.5.8",
         "@types/node": "^20.9.0",
         "jest": "^29.7.0",
@@ -940,6 +941,22 @@
         "raw-body": "^3.0.0",
         "zod": "^3.23.8",
         "zod-to-json-schema": "^3.24.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
+      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
       },
       "engines": {
         "node": ">=18"
@@ -4091,6 +4108,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
+      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.57.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
+      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "start": "node dist/cli.js",
     "dev": "ts-node src/index.ts",
     "test": "jest --passWithNoTests",
+    "inspector": "npx @modelcontextprotocol/inspector node dist/index.js",
+    "inspector:headless": "BROWSER=none npx @modelcontextprotocol/inspector node dist/index.js",
+    "e2e:test": "playwright test",
+    "e2e:ui": "playwright test --ui",
+    "e2e:report": "playwright show-report",
     "prepublishOnly": "npm run build"
   },
   "keywords": [
@@ -32,6 +37,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.57.0",
     "@types/jest": "^29.5.8",
     "@types/node": "^20.9.0",
     "jest": "^29.7.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,40 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Test environment defaults
+const TEST_REDASH_URL = process.env.REDASH_URL || 'https://demo.redash.io';
+const TEST_REDASH_API_KEY = process.env.REDASH_API_KEY || 'test_api_key';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  timeout: 60000,
+  reporter: [
+    ['html'],
+    ['list']
+  ],
+  use: {
+    baseURL: 'http://localhost:6274',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    actionTimeout: 15000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: process.env.SKIP_WEBSERVER ? undefined : {
+    command: `REDASH_URL=${TEST_REDASH_URL} REDASH_API_KEY=${TEST_REDASH_API_KEY} DANGEROUSLY_OMIT_AUTH=true npm run inspector`,
+    url: 'http://localhost:6274',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+});

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Integration tests for MCP server
+ *
+ * These tests verify the integration between different components
+ * of the Redash MCP server.
+ */
+
+// Set environment variables before any imports
+process.env.REDASH_URL = 'https://redash.example.com';
+process.env.REDASH_API_KEY = 'test-api-key';
+process.env.REDASH_TIMEOUT = '30000';
+
+import { redashClient } from '../redashClient.js';
+import { logger } from '../logger.js';
+import { jest } from '@jest/globals';
+
+// Mock axios to avoid real API calls
+jest.mock('axios');
+
+describe('MCP Server Integration', () => {
+  beforeEach(() => {
+    // Set up environment variables for testing
+    process.env.REDASH_URL = 'https://redash.example.com';
+    process.env.REDASH_API_KEY = 'test-api-key';
+  });
+
+  describe('redashClient and logger integration', () => {
+    it('should use logger for error reporting', async () => {
+      const errorSpy = jest.spyOn(logger, 'error');
+
+      // Mock axios to throw an error
+      const axios = await import('axios');
+      const mockedAxios = axios as any;
+
+      if (mockedAxios.create) {
+        const mockInstance = {
+          get: jest.fn<any>().mockRejectedValue(new Error('Network error')),
+          defaults: { headers: {} },
+        };
+        mockedAxios.create.mockReturnValue(mockInstance as any);
+      }
+
+      try {
+        await redashClient.getQueries();
+      } catch (error) {
+        // Expected to fail
+      }
+
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+  });
+
+  describe('Environment configuration', () => {
+    it('should require REDASH_URL and REDASH_API_KEY', () => {
+      const originalUrl = process.env.REDASH_URL;
+      const originalKey = process.env.REDASH_API_KEY;
+
+      delete process.env.REDASH_URL;
+      delete process.env.REDASH_API_KEY;
+
+      // This should be tested in RedashClient constructor
+      expect(() => {
+        // Constructor is called when importing, so we need to re-import
+        const { RedashClient } = require('../redashClient.js');
+        new RedashClient();
+      }).toThrow();
+
+      // Restore
+      process.env.REDASH_URL = originalUrl;
+      process.env.REDASH_API_KEY = originalKey;
+    });
+  });
+
+  describe('Tool schemas validation', () => {
+    it('should validate query creation parameters', () => {
+      const { z } = require('zod');
+
+      const createQuerySchema = z.object({
+        name: z.string(),
+        data_source_id: z.number(),
+        query: z.string(),
+        description: z.string().optional(),
+        options: z.any().optional(),
+        schedule: z.any().optional(),
+        tags: z.array(z.string()).optional()
+      });
+
+      const validData = {
+        name: 'Test Query',
+        data_source_id: 1,
+        query: 'SELECT 1',
+      };
+
+      expect(() => createQuerySchema.parse(validData)).not.toThrow();
+
+      const invalidData = {
+        name: 'Test Query',
+        // missing data_source_id
+        query: 'SELECT 1',
+      };
+
+      expect(() => createQuerySchema.parse(invalidData)).toThrow();
+    });
+
+    it('should validate query update parameters', () => {
+      const { z } = require('zod');
+
+      const updateQuerySchema = z.object({
+        queryId: z.number(),
+        name: z.string().optional(),
+        data_source_id: z.number().optional(),
+        query: z.string().optional(),
+        description: z.string().optional(),
+        options: z.any().optional(),
+        schedule: z.any().optional(),
+        tags: z.array(z.string()).optional(),
+        is_archived: z.boolean().optional(),
+        is_draft: z.boolean().optional()
+      });
+
+      const validData = {
+        queryId: 123,
+        name: 'Updated Query',
+      };
+
+      expect(() => updateQuerySchema.parse(validData)).not.toThrow();
+
+      const invalidData = {
+        // missing queryId
+        name: 'Updated Query',
+      };
+
+      expect(() => updateQuerySchema.parse(invalidData)).toThrow();
+    });
+
+    it('should validate execute query parameters', () => {
+      const { z } = require('zod');
+
+      const executeQuerySchema = z.object({
+        queryId: z.number(),
+        parameters: z.record(z.any()).optional()
+      });
+
+      const validData = {
+        queryId: 123,
+        parameters: { date: '2024-01-01' },
+      };
+
+      expect(() => executeQuerySchema.parse(validData)).not.toThrow();
+
+      const validDataWithoutParams = {
+        queryId: 123,
+      };
+
+      expect(() => executeQuerySchema.parse(validDataWithoutParams)).not.toThrow();
+    });
+
+    it('should validate visualization creation parameters', () => {
+      const { z } = require('zod');
+
+      const createVisualizationSchema = z.object({
+        query_id: z.number(),
+        type: z.string(),
+        name: z.string(),
+        description: z.string().optional(),
+        options: z.any()
+      });
+
+      const validData = {
+        query_id: 1,
+        type: 'CHART',
+        name: 'Test Chart',
+        options: { chartType: 'bar' },
+      };
+
+      expect(() => createVisualizationSchema.parse(validData)).not.toThrow();
+
+      const invalidData = {
+        query_id: 1,
+        type: 'CHART',
+        // missing name and options
+      };
+
+      expect(() => createVisualizationSchema.parse(invalidData)).toThrow();
+    });
+  });
+
+  describe('Resource URI parsing', () => {
+    it('should parse query resource URIs', () => {
+      const uri = 'redash://query/123';
+      const match = uri.match(/^redash:\/\/(query|dashboard)\/(\d+)$/);
+
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('query');
+      expect(match![2]).toBe('123');
+    });
+
+    it('should parse dashboard resource URIs', () => {
+      const uri = 'redash://dashboard/456';
+      const match = uri.match(/^redash:\/\/(query|dashboard)\/(\d+)$/);
+
+      expect(match).not.toBeNull();
+      expect(match![1]).toBe('dashboard');
+      expect(match![2]).toBe('456');
+    });
+
+    it('should reject invalid resource URIs', () => {
+      const invalidUris = [
+        'redash://invalid/123',
+        'redash://query/abc',
+        'invalid://query/123',
+        'redash://query',
+      ];
+
+      invalidUris.forEach((uri) => {
+        const match = uri.match(/^redash:\/\/(query|dashboard)\/(\d+)$/);
+        expect(match).toBeNull();
+      });
+    });
+  });
+});

--- a/src/__tests__/logger.test.ts
+++ b/src/__tests__/logger.test.ts
@@ -1,0 +1,157 @@
+import { Logger, LogLevel } from '../logger.js';
+import { jest } from '@jest/globals';
+
+describe('Logger', () => {
+  let logger: Logger;
+  let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
+
+  beforeEach(() => {
+    logger = new Logger();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('log levels', () => {
+    it('should log debug messages', () => {
+      logger.debug('Debug message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[DEBUG] Debug message');
+    });
+
+    it('should log info messages', () => {
+      logger.info('Info message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[INFO] Info message');
+    });
+
+    it('should log warning messages', () => {
+      logger.warning('Warning message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[WARNING] Warning message');
+    });
+
+    it('should log error messages', () => {
+      logger.error('Error message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[ERROR] Error message');
+    });
+
+    it('should log custom level messages', () => {
+      logger.log(LogLevel.CRITICAL, 'Critical message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[CRITICAL] Critical message');
+    });
+  });
+
+  describe('server notifications', () => {
+    it('should send notification when server is set', () => {
+      const mockNotification = jest.fn();
+      const mockServer = {
+        notification: mockNotification,
+      };
+
+      logger.setServer(mockServer);
+      logger.info('Test message');
+
+      expect(mockNotification).toHaveBeenCalledWith({
+        method: 'notifications/logging',
+        params: {
+          level: LogLevel.INFO,
+          data: 'Test message',
+        },
+      });
+    });
+
+    it('should not send notification when server is not set', () => {
+      logger.info('Test message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[INFO] Test message');
+      // No error should be thrown
+    });
+
+    it('should handle notification errors gracefully', () => {
+      const mockNotification = jest.fn().mockImplementation(() => {
+        throw new Error('Notification error');
+      });
+      const mockServer = {
+        notification: mockNotification,
+      };
+
+      logger.setServer(mockServer);
+      logger.info('Test message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[INFO] Test message');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to send log notification')
+      );
+    });
+
+    it('should handle server without notification method', () => {
+      const mockServer = {};
+
+      logger.setServer(mockServer);
+      logger.info('Test message');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[INFO] Test message');
+      // Should not throw error
+    });
+  });
+
+  describe('log method', () => {
+    it('should always log to console.error', () => {
+      const mockServer = {
+        notification: jest.fn(),
+      };
+
+      logger.setServer(mockServer);
+      logger.log(LogLevel.DEBUG, 'Test');
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('[DEBUG] Test');
+    });
+
+    it('should handle all log levels', () => {
+      const levels = [
+        LogLevel.DEBUG,
+        LogLevel.INFO,
+        LogLevel.NOTICE,
+        LogLevel.WARNING,
+        LogLevel.ERROR,
+        LogLevel.CRITICAL,
+        LogLevel.ALERT,
+        LogLevel.EMERGENCY,
+      ];
+
+      levels.forEach((level) => {
+        consoleErrorSpy.mockClear();
+        logger.log(level, 'Test message');
+
+        expect(consoleErrorSpy).toHaveBeenCalledWith(
+          `[${level.toUpperCase()}] Test message`
+        );
+      });
+    });
+  });
+
+  describe('setServer', () => {
+    it('should update server instance', () => {
+      const mockServer1 = {
+        notification: jest.fn(),
+      };
+      const mockServer2 = {
+        notification: jest.fn(),
+      };
+
+      logger.setServer(mockServer1);
+      logger.info('Message 1');
+
+      logger.setServer(mockServer2);
+      logger.info('Message 2');
+
+      expect(mockServer1.notification).toHaveBeenCalledTimes(1);
+      expect(mockServer2.notification).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/__tests__/redashClient.test.ts
+++ b/src/__tests__/redashClient.test.ts
@@ -1,0 +1,592 @@
+// Set environment variables before any imports
+process.env.REDASH_URL = 'https://redash.example.com';
+process.env.REDASH_API_KEY = 'test-api-key';
+process.env.REDASH_TIMEOUT = '30000';
+
+import { RedashClient } from '../redashClient.js';
+import axios from 'axios';
+import { jest } from '@jest/globals';
+
+// Mock axios
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+// Mock logger
+jest.mock('../logger.js', () => ({
+  logger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    log: jest.fn(),
+  },
+}));
+
+describe('RedashClient', () => {
+  let client: RedashClient;
+  let mockAxiosInstance: any;
+
+  beforeEach(() => {
+    // Reset environment variables
+    process.env.REDASH_URL = 'https://redash.example.com';
+    process.env.REDASH_API_KEY = 'test-api-key';
+    process.env.REDASH_TIMEOUT = '30000';
+    delete process.env.REDASH_EXTRA_HEADERS;
+
+    // Setup axios mock
+    mockAxiosInstance = {
+      get: jest.fn(),
+      post: jest.fn(),
+      delete: jest.fn(),
+      defaults: {
+        headers: {},
+      },
+    };
+
+    mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
+
+    client = new RedashClient();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should throw error if REDASH_URL is not set', () => {
+      delete process.env.REDASH_URL;
+      expect(() => new RedashClient()).toThrow(
+        'REDASH_URL and REDASH_API_KEY must be provided in .env file'
+      );
+    });
+
+    it('should throw error if REDASH_API_KEY is not set', () => {
+      delete process.env.REDASH_API_KEY;
+      expect(() => new RedashClient()).toThrow(
+        'REDASH_URL and REDASH_API_KEY must be provided in .env file'
+      );
+    });
+
+    it('should create axios instance with correct config', () => {
+      expect(mockedAxios.create).toHaveBeenCalledWith({
+        baseURL: 'https://redash.example.com',
+        headers: {
+          Authorization: 'Key test-api-key',
+          'Content-Type': 'application/json',
+        },
+        timeout: 30000,
+      });
+    });
+
+    it('should parse JSON extra headers', () => {
+      process.env.REDASH_EXTRA_HEADERS = '{"CF-Access-Client-Id":"test-id","CF-Access-Client-Secret":"test-secret"}';
+
+      mockedAxios.create.mockClear();
+      new RedashClient();
+
+      expect(mockedAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'CF-Access-Client-Id': 'test-id',
+            'CF-Access-Client-Secret': 'test-secret',
+          }),
+        })
+      );
+    });
+
+    it('should parse key=value extra headers', () => {
+      process.env.REDASH_EXTRA_HEADERS = 'X-Custom-Header=value1;X-Another-Header=value2';
+
+      mockedAxios.create.mockClear();
+      new RedashClient();
+
+      expect(mockedAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            'X-Custom-Header': 'value1',
+            'X-Another-Header': 'value2',
+          }),
+        })
+      );
+    });
+
+    it('should prevent Authorization header override', () => {
+      process.env.REDASH_EXTRA_HEADERS = '{"Authorization":"malicious-key"}';
+
+      mockedAxios.create.mockClear();
+      new RedashClient();
+
+      const callArgs = mockedAxios.create.mock.calls[0]?.[0];
+      expect(callArgs?.headers).toBeDefined();
+      expect((callArgs?.headers as any)?.Authorization).toBe('Key test-api-key');
+    });
+  });
+
+  describe('getQueries', () => {
+    it('should fetch queries with pagination', async () => {
+      const mockResponse = {
+        data: {
+          count: 100,
+          page: 1,
+          page_size: 25,
+          results: [
+            { id: 1, name: 'Query 1' },
+            { id: 2, name: 'Query 2' },
+          ],
+        },
+      };
+
+      mockAxiosInstance.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getQueries(1, 25);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/queries', {
+        params: { page: 1, page_size: 25, q: undefined },
+      });
+      expect(result).toEqual({
+        count: 100,
+        page: 1,
+        pageSize: 25,
+        results: mockResponse.data.results,
+      });
+    });
+
+    it('should fetch queries with search query', async () => {
+      const mockResponse = {
+        data: {
+          count: 10,
+          page: 1,
+          page_size: 25,
+          results: [{ id: 1, name: 'Test Query' }],
+        },
+      };
+
+      mockAxiosInstance.get.mockResolvedValue(mockResponse);
+
+      await client.getQueries(1, 25, 'test');
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/queries', {
+        params: { page: 1, page_size: 25, q: 'test' },
+      });
+    });
+
+    it('should throw error on failure', async () => {
+      mockAxiosInstance.get.mockRejectedValue(new Error('Network error'));
+
+      await expect(client.getQueries()).rejects.toThrow(
+        'Failed to fetch queries from Redash'
+      );
+    });
+  });
+
+  describe('getQuery', () => {
+    it('should fetch a specific query', async () => {
+      const mockQuery = {
+        id: 1,
+        name: 'Test Query',
+        query: 'SELECT * FROM users',
+      };
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockQuery });
+
+      const result = await client.getQuery(1);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/queries/1');
+      expect(result).toEqual(mockQuery);
+    });
+
+    it('should throw error on failure', async () => {
+      mockAxiosInstance.get.mockRejectedValue(new Error('Not found'));
+
+      await expect(client.getQuery(999)).rejects.toThrow(
+        'Failed to fetch query 999 from Redash'
+      );
+    });
+  });
+
+  describe('createQuery', () => {
+    it('should create a new query', async () => {
+      const queryData = {
+        name: 'New Query',
+        data_source_id: 1,
+        query: 'SELECT 1',
+        description: 'Test',
+      };
+
+      const mockResponse = {
+        data: {
+          id: 123,
+          ...queryData,
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const result = await client.createQuery(queryData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/queries',
+        expect.objectContaining({
+          name: 'New Query',
+          data_source_id: 1,
+          query: 'SELECT 1',
+          description: 'Test',
+        })
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should handle API errors', async () => {
+      const queryData = {
+        name: 'New Query',
+        data_source_id: 1,
+        query: 'SELECT 1',
+      };
+
+      const axiosError = {
+        response: {
+          status: 400,
+          data: { message: 'Invalid query' },
+        },
+        config: {},
+      };
+
+      mockAxiosInstance.post.mockRejectedValue(axiosError);
+
+      await expect(client.createQuery(queryData)).rejects.toThrow(
+        /Redash API error \(400\)/
+      );
+    });
+  });
+
+  describe('updateQuery', () => {
+    it('should update a query', async () => {
+      const updateData = {
+        name: 'Updated Query',
+        description: 'Updated description',
+      };
+
+      const mockResponse = {
+        data: {
+          id: 1,
+          ...updateData,
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const result = await client.updateQuery(1, updateData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/queries/1',
+        updateData
+      );
+      expect(result).toEqual(mockResponse.data);
+    });
+
+    it('should only include defined fields', async () => {
+      const updateData = {
+        name: 'Updated Query',
+        description: undefined,
+      };
+
+      mockAxiosInstance.post.mockResolvedValue({ data: {} });
+
+      await client.updateQuery(1, updateData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/queries/1', {
+        name: 'Updated Query',
+      });
+    });
+  });
+
+  describe('archiveQuery', () => {
+    it('should archive a query', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({});
+
+      const result = await client.archiveQuery(1);
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/queries/1');
+      expect(result).toEqual({ success: true });
+    });
+
+    it('should throw error on failure', async () => {
+      mockAxiosInstance.delete.mockRejectedValue(new Error('Not found'));
+
+      await expect(client.archiveQuery(999)).rejects.toThrow(
+        'Failed to archive query 999'
+      );
+    });
+  });
+
+  describe('executeQuery', () => {
+    it('should execute a query and return immediate results', async () => {
+      const mockResult = {
+        id: 1,
+        query_id: 123,
+        data: {
+          columns: [{ name: 'id', type: 'integer' }],
+          rows: [{ id: 1 }],
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue({ data: mockResult });
+
+      const result = await client.executeQuery(123);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/queries/123/results',
+        { parameters: undefined }
+      );
+      expect(result).toEqual(mockResult);
+    });
+
+    it('should execute a query with parameters', async () => {
+      const params = { date: '2024-01-01' };
+      mockAxiosInstance.post.mockResolvedValue({ data: {} });
+
+      await client.executeQuery(123, params);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/queries/123/results',
+        { parameters: params }
+      );
+    });
+
+    it('should poll for async results', async () => {
+      const jobId = 'job-123';
+      const mockJobResponse = {
+        data: {
+          job: {
+            id: jobId,
+          },
+        },
+      };
+
+      const mockPollResponse = {
+        data: {
+          job: {
+            status: 3,
+            result: {
+              id: 1,
+              data: { columns: [], rows: [] },
+            },
+          },
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue(mockJobResponse);
+      mockAxiosInstance.get.mockResolvedValue(mockPollResponse);
+
+      const result = await client.executeQuery(123);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith(`/api/jobs/${jobId}`);
+      expect(result).toEqual(mockPollResponse.data.job.result);
+    });
+  });
+
+  describe('executeAdhocQuery', () => {
+    it('should execute an adhoc query', async () => {
+      const mockResult = {
+        id: 1,
+        data: {
+          columns: [{ name: 'count', type: 'integer' }],
+          rows: [{ count: 5 }],
+        },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue({ data: mockResult });
+
+      const result = await client.executeAdhocQuery('SELECT COUNT(*) as count FROM users', 1);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith(
+        '/api/query_results',
+        expect.objectContaining({
+          query: 'SELECT COUNT(*) as count FROM users',
+          data_source_id: 1,
+          max_age: 0,
+        })
+      );
+      expect(result).toEqual(mockResult);
+    });
+  });
+
+  describe('getDataSources', () => {
+    it('should fetch data sources', async () => {
+      const mockDataSources = [
+        { id: 1, name: 'PostgreSQL' },
+        { id: 2, name: 'MySQL' },
+      ];
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockDataSources });
+
+      const result = await client.getDataSources();
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources');
+      expect(result).toEqual(mockDataSources);
+    });
+  });
+
+  describe('getDashboards', () => {
+    it('should fetch dashboards', async () => {
+      const mockResponse = {
+        data: {
+          count: 10,
+          page: 1,
+          page_size: 25,
+          results: [
+            { id: 1, name: 'Dashboard 1' },
+            { id: 2, name: 'Dashboard 2' },
+          ],
+        },
+      };
+
+      mockAxiosInstance.get.mockResolvedValue(mockResponse);
+
+      const result = await client.getDashboards(1, 25);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/dashboards', {
+        params: { page: 1, page_size: 25 },
+      });
+      expect(result).toEqual({
+        count: 10,
+        page: 1,
+        pageSize: 25,
+        results: mockResponse.data.results,
+      });
+    });
+  });
+
+  describe('getDashboard', () => {
+    it('should fetch a specific dashboard', async () => {
+      const mockDashboard = {
+        id: 1,
+        name: 'Test Dashboard',
+        widgets: [],
+      };
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockDashboard });
+
+      const result = await client.getDashboard(1);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/dashboards/1');
+      expect(result).toEqual(mockDashboard);
+    });
+  });
+
+  describe('getVisualization', () => {
+    it('should fetch a specific visualization', async () => {
+      const mockVisualization = {
+        id: 1,
+        type: 'CHART',
+        name: 'Test Chart',
+        options: {},
+      };
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockVisualization });
+
+      const result = await client.getVisualization(1);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/visualizations/1');
+      expect(result).toEqual(mockVisualization);
+    });
+  });
+
+  describe('createVisualization', () => {
+    it('should create a visualization', async () => {
+      const vizData = {
+        query_id: 1,
+        type: 'CHART',
+        name: 'New Chart',
+        options: { chartType: 'bar' },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 123, ...vizData } });
+
+      const result = await client.createVisualization(vizData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/visualizations', vizData);
+      expect(result.id).toBe(123);
+    });
+  });
+
+  describe('updateVisualization', () => {
+    it('should update a visualization', async () => {
+      const updateData = {
+        name: 'Updated Chart',
+        options: { chartType: 'line' },
+      };
+
+      mockAxiosInstance.post.mockResolvedValue({ data: { id: 1, ...updateData } });
+
+      const result = await client.updateVisualization(1, updateData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/visualizations/1', updateData);
+      expect(result.name).toBe('Updated Chart');
+    });
+  });
+
+  describe('deleteVisualization', () => {
+    it('should delete a visualization', async () => {
+      mockAxiosInstance.delete.mockResolvedValue({});
+
+      await client.deleteVisualization(1);
+
+      expect(mockAxiosInstance.delete).toHaveBeenCalledWith('/api/visualizations/1');
+    });
+  });
+
+  describe('getQueryResultsAsCsv', () => {
+    it('should fetch CSV results without refresh', async () => {
+      const mockCsv = 'id,name\n1,test\n2,test2';
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockCsv });
+
+      const result = await client.getQueryResultsAsCsv(1, false);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/queries/1/results.csv', {
+        responseType: 'text',
+      });
+      expect(result).toBe(mockCsv);
+    });
+
+    it('should refresh before fetching CSV results', async () => {
+      const mockCsv = 'id,name\n1,test';
+
+      mockAxiosInstance.post.mockResolvedValue({ data: {} });
+      mockAxiosInstance.get.mockResolvedValue({ data: mockCsv });
+
+      await client.getQueryResultsAsCsv(1, true);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/queries/1/results', {
+        parameters: undefined,
+      });
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/queries/1/results.csv', {
+        responseType: 'text',
+      });
+    });
+  });
+
+  describe('getSchema', () => {
+    it('should fetch data source schema', async () => {
+      const mockSchema = {
+        schema: [
+          {
+            name: 'users',
+            columns: [
+              { name: 'id', type: 'integer' },
+              { name: 'email', type: 'string' },
+            ],
+          },
+        ],
+      };
+
+      mockAxiosInstance.get.mockResolvedValue({ data: mockSchema });
+
+      const result = await client.getSchema(1);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources/1/schema');
+      expect(result).toEqual(mockSchema);
+    });
+  });
+});


### PR DESCRIPTION
Thanks for creating and maintaining this MCP server - I've been using it in my workflow and it's been really helpful for integrating Redash with Claude.

I noticed the project doesn't have automated tests yet, so I put together some test coverage to help make the codebase more maintainable and catch potential issues early. This should make it easier to confidently make changes and refactor in the future.

I've added both unit tests (30 tests using Jest) and E2E tests (2 tests using Playwright + MCP Inspector). The unit tests cover RedashClient functionality like query CRUD operations, execution, and HTTP header parsing, as well as the Logger and environment validation. The E2E tests verify the server connection flow and check that all 16 tools are available through the MCP Inspector.

Let me know if you'd like any changes or additional test coverage!