### PR TITLE
Add npm metadata for source and issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "@suthio/redash-mcp",
   "version": "0.0.13",
   "description": "MCP server for Redash integration",
+  "homepage": "https://github.com/suthio/redash-mcp#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/suthio/redash-mcp.git"
+  },
+  "bugs": {
+    "url": "https://github.com/suthio/redash-mcp/issues"
+  },
   "type": "module",
   "bin": {
     "redash-mcp": "./dist/cli.js"


### PR DESCRIPTION
## Summary
- add package-level homepage, repository, and bugs metadata for `@suthio/redash-mcp`
- point npm users directly to the GitHub README, source repository, and issue tracker

## Validation
- `node -e "const p=require('./package.json'); if(!p.homepage||!p.repository?.url||!p.bugs?.url) process.exit(1);"`
- `npm pack --dry-run --ignore-scripts`
- `git diff --check`