### PR TITLE
Add per-request authentication via Authorization header for HTTP transport

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
-# Redash Instance URL (required)
+# Redash Instance URL (required, regardless of transport)
+# One process talks to exactly one Redash instance.
 REDASH_URL=https://your-redash-instance.com
 
-# Redash API Key (required)
+# Redash API Key.
+# - stdio transport (default): required. One process per user, one static key.
+# - http transport: optional. Each incoming MCP request should carry its own
+#   personal Redash API token in its `Authorization` header instead (e.g.
+#   `Authorization: Bearer <token>` or `Authorization: Key <token>`). This
+#   variable then only serves as a fallback for requests without their own
+#   Authorization header.
 REDASH_API_KEY=your_api_key
 
 # Optional: Timeout for API requests in milliseconds
@@ -30,3 +37,9 @@ REDASH_MAX_RESULTS=1000
 # Redash error bodies are omitted by default. Enable only when the trace and
 # log backends are approved to store that content. Credentials stay excluded.
 # OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
+
+# --- HTTP (Streamable HTTP) transport settings, only used when MCP_TRANSPORT=http ---
+# MCP_TRANSPORT=http
+# MCP_HTTP_HOST=127.0.0.1
+# MCP_HTTP_PORT=3000
+# MCP_HTTP_PATH=/mcp

--- a/README.md
+++ b/README.md
@@ -128,7 +128,6 @@ The server can also run as a stateless Streamable HTTP MCP server. The HTTP entr
 
 ```bash
 REDASH_URL=https://your-redash-instance.com \
-REDASH_API_KEY=your_api_key \
 MCP_TRANSPORT=http \
 pnpm start
 ```
@@ -137,9 +136,10 @@ This starts `POST http://127.0.0.1:3000/mcp` by default. CLI flags override envi
 
 ```bash
 REDASH_URL=https://your-redash-instance.com \
-REDASH_API_KEY=your_api_key \
 pnpm start --transport http --host 127.0.0.1 --port 3333 --path /mcp
 ```
+
+Note: `REDASH_API_KEY` is not needed here - in HTTP mode each MCP client request supplies its own Redash token via its `Authorization` header (see below). You can still set `REDASH_API_KEY` as a fallback for requests that don't send one.
 
 For a non-local bind behind an authenticated, TLS-terminating reverse proxy, explicitly configure which request hosts and browser origins may reach the server. The equivalent CLI options are `--allowed-hosts` and `--allowed-origins`.
 
@@ -298,6 +298,27 @@ const server = createRedashMcpServer({
 await server.close();
 await shutdownTelemetry();
 ```
+
+### Per-request authentication (multi-user HTTP deployments)
+
+Redash's REST API is stateless and already carries its own auth on every call, so a single HTTP MCP process can safely be shared by many users - there is no need to run one process per user.
+
+In HTTP transport mode, the server reads the Redash API token from **each incoming MCP request's own `Authorization` header** instead of the process-wide `REDASH_API_KEY` environment variable. This lets every user authenticate with their own personal Redash access token while `REDASH_URL` (and the process itself) stays shared and static:
+
+```bash
+# Client sends its own personal Redash token per request, e.g.:
+# Authorization: Bearer <personal-redash-token>
+# or
+# Authorization: Key <personal-redash-token>
+```
+
+Both `Bearer <token>` and `Key <token>` prefixes are accepted (the raw token is extracted either way); a bare token with no prefix also works. The token is then forwarded to Redash using Redash's own `Key <token>` scheme, regardless of how the client sent it.
+
+If a request has no `Authorization` header, the server falls back to the static `REDASH_API_KEY` environment variable if one is set. If neither is available, the request fails with a clear error instead of silently using someone else's token.
+
+This is why `REDASH_API_KEY` is optional (not required) when `MCP_TRANSPORT=http`. In stdio mode `REDASH_API_KEY` remains required exactly as before - stdio has no per-request headers, so nothing changes for existing stdio users.
+
+A typical deployment behind nginx: one HTTP MCP process per Redash instance (e.g. one per environment, such as staging and production), with nginx handling TLS/path routing, and each user's MCP client configured to send their own personal Redash token as the `Authorization` header.
 
 ## Docker
 

--- a/src/__tests__/httpServer.test.ts
+++ b/src/__tests__/httpServer.test.ts
@@ -428,6 +428,90 @@ describe("HTTP MCP server", () => {
       await noAuthClient.close();
     }
   });
+
+  it("rejects requests carrying an interleaved/concurrent set of Authorization headers with each request retaining its own token", async () => {
+    const serverInfo = await startTestServer();
+    const url = new URL(`${serverInfo.baseUrl}/mcp`);
+
+    // Two users, each with their own personal Redash token, calling the same
+    // shared HTTP MCP process at the same time. The security property this
+    // exercises - AsyncLocalStorage context isolation - only shows up under
+    // genuine concurrency: if the two requests' async call chains were
+    // accidentally sharing state, interleaving their execution (rather than
+    // awaiting one fully before starting the other) is what would surface
+    // it, e.g. as user B's token leaking into user A's outgoing Redash call.
+    const userATransport = new StreamableHTTPClientTransport(url, {
+      requestInit: { headers: { Authorization: "Bearer user-a-token" } },
+    });
+    const userAClient = new Client({ name: "user-a-client", version: "1.0.0" });
+
+    const userBTransport = new StreamableHTTPClientTransport(url, {
+      requestInit: { headers: { Authorization: "Bearer user-b-token" } },
+    });
+    const userBClient = new Client({ name: "user-b-client", version: "1.0.0" });
+
+    try {
+      await Promise.all([
+        userAClient.connect(userATransport),
+        userBClient.connect(userBTransport),
+      ]);
+
+      // Fire both tool calls concurrently (no `await` between them) so their
+      // handling genuinely overlaps in time, then let them interleave freely
+      // before asserting on the outcome.
+      const [resultA, resultB] = await Promise.all([
+        userAClient.callTool({ name: "list_queries", arguments: {} }),
+        userBClient.callTool({ name: "list_queries", arguments: {} }),
+      ]);
+
+      expect(resultA.isError).not.toBe(true);
+      expect(resultB.isError).not.toBe(true);
+
+      // Regardless of interleaving/scheduling order, each captured outgoing
+      // Redash call must carry exactly one of the two users' own tokens -
+      // never a mix, never the other user's token, never the static
+      // fallback key.
+      expect(capturedRedashAuthHeaders).toHaveLength(2);
+      expect(capturedRedashAuthHeaders).toEqual(
+        expect.arrayContaining(["Key user-a-token", "Key user-b-token"]),
+      );
+    } finally {
+      await userAClient.close();
+      await userBClient.close();
+    }
+  });
+
+  describe("rejects a supplied-but-unsupported Authorization header without falling back to REDASH_API_KEY", () => {
+    it.each([
+      ["Basic", "Basic dXNlcjpwYXNz"],
+      ["an empty Bearer", "Bearer"],
+      ["Digest", 'Digest username="foo"'],
+    ])("rejects %s and never forwards the static fallback key", async (_label, headerValue) => {
+      const serverInfo = await startTestServer();
+
+      const response = await fetch(`${serverInfo.baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: headerValue,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "tools/call",
+          params: { name: "list_queries", arguments: {} },
+          id: 1,
+        }),
+      });
+
+      expect(response.status).toBe(401);
+
+      // The request must have been rejected before ever reaching the MCP
+      // handler, so no outgoing Redash call - and in particular none using
+      // the static REDASH_API_KEY fallback - should have happened.
+      expect(capturedRedashAuthHeaders).toHaveLength(0);
+    });
+  });
 });
 
 async function startTestServer(

--- a/src/__tests__/httpServer.test.ts
+++ b/src/__tests__/httpServer.test.ts
@@ -20,11 +20,72 @@ const LOOPBACK_HOSTNAMES = [...LOOPBACK_ALLOWED_HOSTNAMES];
 
 const openHandles: HttpServerHandle[] = [];
 
+// Captures the `Authorization` header actually sent to the (mocked) Redash
+// API for every outgoing call, so tests can assert that each incoming MCP
+// HTTP request's own Authorization header is forwarded 1:1 to Redash -
+// instead of a shared/static REDASH_API_KEY - without hitting a real Redash
+// instance or using real credentials.
+const capturedRedashAuthHeaders: Array<string | undefined> = [];
+
+jest.mock("axios", () => {
+  // Emulates just enough of axios's request-interceptor behavior for the
+  // test below: every `get`/`post`/`delete` call is routed through whatever
+  // interceptor RedashClient registered, and we record the Authorization
+  // header the interceptor produced before "sending" the (fake) request.
+  let interceptor: ((config: any) => any) | undefined;
+
+  const rawGet = async (_url: string, config: any) => {
+    capturedRedashAuthHeaders.push(config?.headers?.Authorization);
+    return { data: { count: 0, page: 1, page_size: 25, results: [] } };
+  };
+  const rawPost = async (_url: string, _body?: any, config?: any) => {
+    capturedRedashAuthHeaders.push(config?.headers?.Authorization);
+    return { data: {} };
+  };
+  const rawDelete = async (_url: string, config?: any) => {
+    capturedRedashAuthHeaders.push(config?.headers?.Authorization);
+    return { data: {} };
+  };
+
+  const instance = {
+    get: jest.fn(async (url: string, config?: any) =>
+      rawGet(url, interceptor ? interceptor({ headers: {}, ...config }) : config)
+    ),
+    post: jest.fn(async (url: string, body?: any, config?: any) =>
+      rawPost(url, body, interceptor ? interceptor({ headers: {}, ...config }) : config)
+    ),
+    delete: jest.fn(async (url: string, config?: any) =>
+      rawDelete(url, interceptor ? interceptor({ headers: {}, ...config }) : config)
+    ),
+    defaults: { headers: {} as Record<string, string> },
+    interceptors: {
+      request: {
+        use: (fn: (config: any) => any) => {
+          interceptor = fn;
+        },
+      },
+    },
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(() => instance),
+      isAxiosError: jest.fn(() => false),
+    },
+  };
+});
+
+beforeEach(() => {
+  capturedRedashAuthHeaders.length = 0;
+});
+
 describe("HTTP MCP server", () => {
   let consoleErrorSpy: jest.SpiedFunction<typeof console.error>;
 
   beforeEach(() => {
     consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    capturedRedashAuthHeaders.length = 0;
   });
 
   afterEach(async () => {
@@ -321,6 +382,50 @@ describe("HTTP MCP server", () => {
       expect(serverInfo.handle.server.listening).toBe(false);
     } finally {
       await client.close();
+    }
+  });
+
+  it("forwards each request's own Authorization header to Redash, per-request", async () => {
+    const serverInfo = await startTestServer();
+    const url = new URL(`${serverInfo.baseUrl}/mcp`);
+
+    // Simulate two different users, each with their own personal Redash
+    // token, calling the same shared HTTP MCP process.
+    const userATransport = new StreamableHTTPClientTransport(url, {
+      requestInit: { headers: { Authorization: "Bearer user-a-token" } },
+    });
+    const userAClient = new Client({ name: "user-a-client", version: "1.0.0" });
+
+    const userBTransport = new StreamableHTTPClientTransport(url, {
+      requestInit: { headers: { Authorization: "Bearer user-b-token" } },
+    });
+    const userBClient = new Client({ name: "user-b-client", version: "1.0.0" });
+
+    // A third "client" that sends no Authorization header at all, to verify
+    // the static REDASH_API_KEY fallback still works (no breaking change
+    // for stdio-style / header-less usage).
+    const noAuthTransport = new StreamableHTTPClientTransport(url);
+    const noAuthClient = new Client({ name: "no-auth-client", version: "1.0.0" });
+
+    try {
+      await userAClient.connect(userATransport);
+      await userAClient.callTool({ name: "list_queries", arguments: {} });
+
+      await userBClient.connect(userBTransport);
+      await userBClient.callTool({ name: "list_queries", arguments: {} });
+
+      await noAuthClient.connect(noAuthTransport);
+      await noAuthClient.callTool({ name: "list_queries", arguments: {} });
+
+      expect(capturedRedashAuthHeaders).toEqual([
+        "Key user-a-token",
+        "Key user-b-token",
+        "Key test-api-key",
+      ]);
+    } finally {
+      await userAClient.close();
+      await userBClient.close();
+      await noAuthClient.close();
     }
   });
 });

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -54,6 +54,11 @@ describe('MCP Server Integration', () => {
         const mockInstance = {
           get: jest.fn<any>().mockRejectedValue(new Error('Network error')),
           defaults: { headers: {} },
+          // RedashClient registers a request interceptor for per-request auth
+          // (see requestAuth.ts); this stub must exist or the RedashClient
+          // constructor throws before the interceptor's own error-logging
+          // logic (asserted below) ever runs.
+          interceptors: { request: { use: jest.fn() } },
         };
         mockedAxios.create.mockReturnValue(mockInstance as any);
       }

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -11,8 +11,27 @@ import { toolDefinitions } from '../index.js';
 import { logger } from '../logger.js';
 import { jest } from '@jest/globals';
 
-// Mock axios to avoid real API calls
-jest.mock('axios');
+// Mock axios to avoid real API calls. Provide a default stub instance
+// (including `interceptors`) so the module-level `redashClient` singleton -
+// constructed as a side effect of the `import` above, before any test body
+// runs - doesn't blow up on `this.client.interceptors...`.
+jest.mock('axios', () => {
+  const defaultInstance = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    defaults: { headers: {} },
+    interceptors: { request: { use: jest.fn() } },
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(() => defaultInstance),
+      isAxiosError: jest.fn(),
+    },
+  };
+});
 
 function getToolInputSchema(name: string) {
   const tool = toolDefinitions.find((definition) => definition.name === name);

--- a/src/__tests__/redashClient.test.ts
+++ b/src/__tests__/redashClient.test.ts
@@ -4,8 +4,27 @@ import { jest } from '@jest/globals';
 import { logger } from '../logger.js';
 import { isToolContentCaptureEnabled } from '../telemetry.js';
 
-// Mock axios
-jest.mock('axios');
+// Mock axios. Provide a default stub instance (including `interceptors`) so
+// that the module-level `redashClient` singleton in `../redashClient.js` -
+// which is constructed as a side effect of the very `import` above, before
+// any `beforeEach` runs - doesn't blow up on `this.client.interceptors...`.
+jest.mock('axios', () => {
+  const defaultInstance = {
+    get: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+    defaults: { headers: {} },
+    interceptors: { request: { use: jest.fn() } },
+  };
+
+  return {
+    __esModule: true,
+    default: {
+      create: jest.fn(() => defaultInstance),
+      isAxiosError: jest.fn(),
+    },
+  };
+});
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 // Mock logger
@@ -44,6 +63,11 @@ describe('RedashClient', () => {
       defaults: {
         headers: {},
       },
+      interceptors: {
+        request: {
+          use: jest.fn(),
+        },
+      },
     };
 
     mockedAxios.create.mockReturnValue(mockAxiosInstance as any);
@@ -59,15 +83,23 @@ describe('RedashClient', () => {
     it('should throw error if REDASH_URL is not set', () => {
       delete process.env.REDASH_URL;
       expect(() => new RedashClient()).toThrow(
-        'REDASH_URL and REDASH_API_KEY must be provided in .env file'
+        'REDASH_URL must be provided in .env file'
       );
     });
 
-    it('should throw error if REDASH_API_KEY is not set', () => {
+    it('should NOT throw if REDASH_API_KEY is not set (per-request tokens are supported in HTTP mode)', () => {
       delete process.env.REDASH_API_KEY;
-      expect(() => new RedashClient()).toThrow(
-        'REDASH_URL and REDASH_API_KEY must be provided in .env file'
-      );
+      expect(() => new RedashClient()).not.toThrow();
+    });
+
+    it('should not set a default Authorization header if REDASH_API_KEY is not set', () => {
+      delete process.env.REDASH_API_KEY;
+      mockedAxios.create.mockClear();
+
+      new RedashClient();
+
+      const callArgs = mockedAxios.create.mock.calls[0]?.[0];
+      expect((callArgs?.headers as any)?.Authorization).toBeUndefined();
     });
 
     it('should create axios instance with correct config', () => {
@@ -79,6 +111,10 @@ describe('RedashClient', () => {
         },
         timeout: 30000,
       });
+    });
+
+    it('should register a request interceptor for per-request auth', () => {
+      expect(mockAxiosInstance.interceptors.request.use).toHaveBeenCalledTimes(1);
     });
 
     it('should parse JSON extra headers', () => {
@@ -122,6 +158,48 @@ describe('RedashClient', () => {
       const callArgs = mockedAxios.create.mock.calls[0]?.[0];
       expect(callArgs?.headers).toBeDefined();
       expect((callArgs?.headers as any)?.Authorization).toBe('Key test-api-key');
+    });
+  });
+
+  describe('per-request auth (HTTP transport)', () => {
+    function getInterceptor(): (config: any) => any {
+      // Use the most recently registered interceptor, in case a test
+      // constructs an additional RedashClient instance against the same
+      // mocked axios instance.
+      const calls = mockAxiosInstance.interceptors.request.use.mock.calls;
+      const call = calls[calls.length - 1];
+      return call[0];
+    }
+
+    it('uses the request-scoped API key over the static REDASH_API_KEY', async () => {
+      const { runWithRedashApiKey } = await import('../requestAuth.js');
+      const interceptor = getInterceptor();
+
+      const config = runWithRedashApiKey('user-token-from-header', () =>
+        interceptor({ headers: {} })
+      );
+
+      expect(config.headers.Authorization).toBe('Key user-token-from-header');
+    });
+
+    it('falls back to the static REDASH_API_KEY when no request-scoped key is bound (stdio mode)', () => {
+      const interceptor = getInterceptor();
+
+      const config = interceptor({ headers: {} });
+
+      expect(config.headers.Authorization).toBe('Key test-api-key');
+    });
+
+    it('throws a clear error if neither a request-scoped key nor REDASH_API_KEY is available', async () => {
+      delete process.env.REDASH_API_KEY;
+      mockedAxios.create.mockClear();
+      client = new RedashClient();
+
+      const interceptor = getInterceptor();
+
+      expect(() => interceptor({ headers: {} })).toThrow(
+        /No Redash API key available for this request/
+      );
     });
   });
 

--- a/src/__tests__/requestAuth.test.ts
+++ b/src/__tests__/requestAuth.test.ts
@@ -1,0 +1,61 @@
+import { extractApiKeyFromAuthorizationHeader } from '../requestAuth.js';
+
+describe('extractApiKeyFromAuthorizationHeader', () => {
+  it('extracts the token from a Bearer scheme header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Bearer abc123xyz')).toBe('abc123xyz');
+  });
+
+  it('extracts the token from a Bearer scheme header case-insensitively', () => {
+    expect(extractApiKeyFromAuthorizationHeader('bearer abc123xyz')).toBe('abc123xyz');
+  });
+
+  it('extracts the token from a Key scheme header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Key abc123xyz')).toBe('abc123xyz');
+  });
+
+  it('extracts the token from a Key scheme header case-insensitively', () => {
+    expect(extractApiKeyFromAuthorizationHeader('key abc123xyz')).toBe('abc123xyz');
+  });
+
+  it('treats a single whitespace-free value with no scheme prefix as a raw token', () => {
+    expect(extractApiKeyFromAuthorizationHeader('abc123xyz')).toBe('abc123xyz');
+  });
+
+  it('rejects a Basic scheme header instead of falling back to a raw token', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Basic dXNlcjpwYXNz')).toBeUndefined();
+  });
+
+  it('rejects other unsupported schemes (e.g. Digest)', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Digest username="foo"')).toBeUndefined();
+  });
+
+  it('returns undefined for an undefined header', () => {
+    expect(extractApiKeyFromAuthorizationHeader(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('')).toBeUndefined();
+  });
+
+  it('returns undefined for a whitespace-only header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('   ')).toBeUndefined();
+  });
+
+  it('returns undefined for a header with only the Bearer keyword and no token', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Bearer')).toBeUndefined();
+  });
+
+  it('returns undefined for a header with only the Key keyword and no token', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Key')).toBeUndefined();
+  });
+
+  it('returns undefined for a Bearer scheme with only trailing whitespace and no token', () => {
+    expect(extractApiKeyFromAuthorizationHeader('Bearer   ')).toBeUndefined();
+  });
+
+  it('uses the first value when the header is provided as an array', () => {
+    expect(extractApiKeyFromAuthorizationHeader(['Bearer abc123xyz', 'Bearer other'])).toBe(
+      'abc123xyz'
+    );
+  });
+});

--- a/src/__tests__/requestAuth.test.ts
+++ b/src/__tests__/requestAuth.test.ts
@@ -2,60 +2,104 @@ import { extractApiKeyFromAuthorizationHeader } from '../requestAuth.js';
 
 describe('extractApiKeyFromAuthorizationHeader', () => {
   it('extracts the token from a Bearer scheme header', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Bearer abc123xyz')).toBe('abc123xyz');
+    expect(extractApiKeyFromAuthorizationHeader('Bearer abc123xyz')).toEqual({
+      status: 'valid',
+      apiKey: 'abc123xyz',
+    });
   });
 
   it('extracts the token from a Bearer scheme header case-insensitively', () => {
-    expect(extractApiKeyFromAuthorizationHeader('bearer abc123xyz')).toBe('abc123xyz');
+    expect(extractApiKeyFromAuthorizationHeader('bearer abc123xyz')).toEqual({
+      status: 'valid',
+      apiKey: 'abc123xyz',
+    });
   });
 
   it('extracts the token from a Key scheme header', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Key abc123xyz')).toBe('abc123xyz');
+    expect(extractApiKeyFromAuthorizationHeader('Key abc123xyz')).toEqual({
+      status: 'valid',
+      apiKey: 'abc123xyz',
+    });
   });
 
   it('extracts the token from a Key scheme header case-insensitively', () => {
-    expect(extractApiKeyFromAuthorizationHeader('key abc123xyz')).toBe('abc123xyz');
+    expect(extractApiKeyFromAuthorizationHeader('key abc123xyz')).toEqual({
+      status: 'valid',
+      apiKey: 'abc123xyz',
+    });
   });
 
   it('treats a single whitespace-free value with no scheme prefix as a raw token', () => {
-    expect(extractApiKeyFromAuthorizationHeader('abc123xyz')).toBe('abc123xyz');
+    expect(extractApiKeyFromAuthorizationHeader('abc123xyz')).toEqual({
+      status: 'valid',
+      apiKey: 'abc123xyz',
+    });
   });
 
   it('rejects a Basic scheme header instead of falling back to a raw token', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Basic dXNlcjpwYXNz')).toBeUndefined();
+    const result = extractApiKeyFromAuthorizationHeader('Basic dXNlcjpwYXNz');
+    expect(result.status).toBe('invalid');
   });
 
   it('rejects other unsupported schemes (e.g. Digest)', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Digest username="foo"')).toBeUndefined();
+    const result = extractApiKeyFromAuthorizationHeader('Digest username="foo"');
+    expect(result.status).toBe('invalid');
   });
 
-  it('returns undefined for an undefined header', () => {
-    expect(extractApiKeyFromAuthorizationHeader(undefined)).toBeUndefined();
+  it('returns "absent" for an undefined header', () => {
+    expect(extractApiKeyFromAuthorizationHeader(undefined)).toEqual({ status: 'absent' });
   });
 
-  it('returns undefined for an empty header', () => {
-    expect(extractApiKeyFromAuthorizationHeader('')).toBeUndefined();
+  it('returns "absent" for an empty header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('')).toEqual({ status: 'absent' });
   });
 
-  it('returns undefined for a whitespace-only header', () => {
-    expect(extractApiKeyFromAuthorizationHeader('   ')).toBeUndefined();
+  it('returns "absent" for a whitespace-only header', () => {
+    expect(extractApiKeyFromAuthorizationHeader('   ')).toEqual({ status: 'absent' });
   });
 
-  it('returns undefined for a header with only the Bearer keyword and no token', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Bearer')).toBeUndefined();
+  it('rejects a header with only the Bearer keyword and no token', () => {
+    const result = extractApiKeyFromAuthorizationHeader('Bearer');
+    expect(result.status).toBe('invalid');
   });
 
-  it('returns undefined for a header with only the Key keyword and no token', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Key')).toBeUndefined();
+  it('rejects a header with only the Key keyword and no token', () => {
+    const result = extractApiKeyFromAuthorizationHeader('Key');
+    expect(result.status).toBe('invalid');
   });
 
-  it('returns undefined for a Bearer scheme with only trailing whitespace and no token', () => {
-    expect(extractApiKeyFromAuthorizationHeader('Bearer   ')).toBeUndefined();
+  it('rejects a Bearer scheme with only trailing whitespace and no token', () => {
+    const result = extractApiKeyFromAuthorizationHeader('Bearer   ');
+    expect(result.status).toBe('invalid');
   });
 
   it('uses the first value when the header is provided as an array', () => {
-    expect(extractApiKeyFromAuthorizationHeader(['Bearer abc123xyz', 'Bearer other'])).toBe(
-      'abc123xyz'
-    );
+    expect(
+      extractApiKeyFromAuthorizationHeader(['Bearer abc123xyz', 'Bearer other'])
+    ).toEqual({ status: 'valid', apiKey: 'abc123xyz' });
+  });
+
+  // Regression coverage for the authentication-boundary bug: a supplied but
+  // invalid/unsupported Authorization header must be distinguishable from
+  // "no header at all", so that callers never fall back to a static
+  // REDASH_API_KEY for a rejected credential. See httpServer.test.ts for the
+  // end-to-end version of this assertion (asserting the HTTP request itself
+  // is rejected and never reaches Redash with the static fallback key).
+  describe('preserves the "absent" vs "invalid" boundary', () => {
+    it('marks a Basic scheme header as invalid, not absent', () => {
+      expect(extractApiKeyFromAuthorizationHeader('Basic dXNlcjpwYXNz').status).toBe('invalid');
+    });
+
+    it('marks an empty Bearer token as invalid, not absent', () => {
+      expect(extractApiKeyFromAuthorizationHeader('Bearer ').status).toBe('invalid');
+    });
+
+    it('marks a Digest scheme header as invalid, not absent', () => {
+      expect(extractApiKeyFromAuthorizationHeader('Digest realm="redash"').status).toBe('invalid');
+    });
+
+    it('marks a missing header as absent, not invalid', () => {
+      expect(extractApiKeyFromAuthorizationHeader(undefined).status).toBe('absent');
+    });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,6 +11,8 @@ if (existsSync(envPath)) {
 }
 
 // Import application modules only after .env has been loaded. The startup
-// module initializes OpenTelemetry before it imports Axios and the MCP server.
+// module initializes OpenTelemetry before it imports Axios and the MCP server,
+// and performs required-environment-variable validation (including the
+// stdio-vs-http REDASH_API_KEY distinction; see startup.ts).
 const { runConfiguredServerCli } = await import('./startup.js');
 await runConfiguredServerCli();

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -16,6 +16,7 @@ import {
 import { cors } from "hono/cors";
 import { createRedashMcpServer } from "./index.js";
 import { logger } from "./logger.js";
+import { extractApiKeyFromAuthorizationHeader, runWithRedashApiKey } from "./requestAuth.js";
 import {
   disableEmbeddedPrometheusMetrics,
   handlePrometheusMetricsRequest,
@@ -76,9 +77,19 @@ export async function startHttpServer(config: HttpServerConfig): Promise<HttpSer
     }));
   }
 
-  app.post(config.path, (context) => handler.fetch(context.req.raw, {
-    parsedBody: context.get("parsedBody"),
-  }));
+  app.post(config.path, (context) => {
+    // Each MCP HTTP request carries its own Redash personal access token in
+    // its `Authorization` header (e.g. `Authorization: Bearer <token>`).
+    // Binding it to this request's async context ensures every RedashClient
+    // call triggered while handling this request - and only this request -
+    // uses this user's token, never a shared/static one. Never log the
+    // extracted token itself.
+    const requestApiKey = extractApiKeyFromAuthorizationHeader(context.req.header("Authorization"));
+
+    return runWithRedashApiKey(requestApiKey, () => handler.fetch(context.req.raw, {
+      parsedBody: context.get("parsedBody"),
+    }));
+  });
   app.on(["GET", "DELETE"], config.path, methodNotAllowed);
 
   if (config.path === HEALTH_CHECK_PATH) {

--- a/src/httpServer.ts
+++ b/src/httpServer.ts
@@ -84,7 +84,18 @@ export async function startHttpServer(config: HttpServerConfig): Promise<HttpSer
     // call triggered while handling this request - and only this request -
     // uses this user's token, never a shared/static one. Never log the
     // extracted token itself.
-    const requestApiKey = extractApiKeyFromAuthorizationHeader(context.req.header("Authorization"));
+    const authResult = extractApiKeyFromAuthorizationHeader(context.req.header("Authorization"));
+
+    // An `Authorization` header that was supplied but rejected (unsupported
+    // scheme, malformed value, ...) must never fall back to the static
+    // REDASH_API_KEY - that would turn a rejected client credential into
+    // unintended access via the shared service-account key. Fail the
+    // request outright instead of forwarding it to the MCP handler.
+    if (authResult.status === "invalid") {
+      return unauthorized(authResult.reason);
+    }
+
+    const requestApiKey = authResult.status === "valid" ? authResult.apiKey : undefined;
 
     return runWithRedashApiKey(requestApiKey, () => handler.fetch(context.req.raw, {
       parsedBody: context.get("parsedBody"),
@@ -249,6 +260,27 @@ function methodNotAllowed() {
       status: 405,
       headers: {
         Allow: "POST",
+        "Content-Type": "application/json",
+      },
+    },
+  );
+}
+
+// The `reason` is a fixed, non-sensitive description of why the header was
+// rejected (e.g. "unsupported scheme") - never the header value itself.
+function unauthorized(reason: string) {
+  return new Response(
+    JSON.stringify({
+      jsonrpc: "2.0",
+      error: {
+        code: -32001,
+        message: `Unauthorized: ${reason}.`,
+      },
+      id: null,
+    }),
+    {
+      status: 401,
+      headers: {
         "Content-Type": "application/json",
       },
     },

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -4,6 +4,7 @@ import { SocksProxyAgent } from 'socks-proxy-agent';
 import { logger, type LogFields } from './logger.js';
 import { isToolContentCaptureEnabled } from './telemetry.js';
 import { formatError } from './utils.js';
+import { getRequestRedashApiKey } from './requestAuth.js';
 
 dotenv.config({ quiet: true });
 
@@ -319,16 +320,28 @@ export class RedashClient {
 
   constructor() {
     this.baseUrl = process.env.REDASH_URL || '';
+    // Static fallback key, used for stdio mode (one process per user) and as a
+    // fallback in HTTP mode when a request doesn't carry its own Authorization
+    // header. NOT required at construction time: in HTTP mode every user
+    // supplies their own personal Redash API token per-request instead, see
+    // `requestAuth.ts` and the request interceptor set up below.
     this.apiKey = process.env.REDASH_API_KEY || '';
 
-    if (!this.baseUrl || !this.apiKey) {
-      throw new Error('REDASH_URL and REDASH_API_KEY must be provided in .env file');
+    if (!this.baseUrl) {
+      throw new Error('REDASH_URL must be provided in .env file');
     }
 
     const defaultHeaders: Record<string, string> = {
-      'Authorization': `Key ${this.apiKey}`,
       'Content-Type': 'application/json'
     };
+
+    // Only set a default Authorization header when a static API key is
+    // configured. If none is configured (pure per-request HTTP mode), the
+    // request interceptor below is responsible for adding it - or for
+    // rejecting the request if no key is available at all.
+    if (this.apiKey) {
+      defaultHeaders['Authorization'] = `Key ${this.apiKey}`;
+    }
 
     const extraHeaders = this.parseExtraHeaders();
 
@@ -355,6 +368,31 @@ export class RedashClient {
     }
 
     this.client = axios.create(axiosConfig);
+
+    // Per-request auth: if the current async context (set up per incoming
+    // MCP HTTP request, see httpServer.ts) carries a Redash API key that was
+    // extracted from that request's own `Authorization` header, use it for
+    // this outgoing call instead of the static `this.apiKey`. In stdio mode
+    // no per-request key is ever bound, so this always falls back to the
+    // header set above (the static REDASH_API_KEY) - no behavior change for
+    // existing stdio users.
+    this.client.interceptors.request.use((config) => {
+      const requestApiKey = getRequestRedashApiKey();
+      const apiKey = requestApiKey || this.apiKey;
+
+      if (!apiKey) {
+        throw new Error(
+          'No Redash API key available for this request. Provide it via the ' +
+          'incoming `Authorization` header (HTTP transport), or set REDASH_API_KEY ' +
+          '(stdio transport / static fallback).'
+        );
+      }
+
+      config.headers = config.headers ?? {};
+      (config.headers as Record<string, unknown>)['Authorization'] = `Key ${apiKey}`;
+
+      return config;
+    });
   }
 
   // Parse extra headers from env var `REDASH_EXTRA_HEADERS`.

--- a/src/requestAuth.ts
+++ b/src/requestAuth.ts
@@ -1,0 +1,68 @@
+// Per-request Redash API key propagation.
+//
+// In stdio mode there is exactly one MCP client per process, so a single
+// REDASH_API_KEY environment variable is enough. In HTTP mode a single
+// process is shared by many users, each with their own personal Redash
+// API token. Those tokens travel with every incoming MCP HTTP request in
+// the standard `Authorization` header and must be used only for the
+// Redash API calls triggered by that specific request.
+//
+// AsyncLocalStorage lets us stash the token for the lifetime of a single
+// request's async call chain (including everything awaited from within
+// it) without threading it through every function signature in index.ts.
+import { AsyncLocalStorage } from "node:async_hooks";
+
+const redashApiKeyStorage = new AsyncLocalStorage<string | undefined>();
+
+/**
+ * Runs `fn` with `apiKey` bound as the "current request's" Redash API key.
+ * Any RedashClient call made (directly or indirectly, including across
+ * awaits) from within `fn` will use this key instead of the static
+ * REDASH_API_KEY env var, unless `apiKey` is undefined.
+ */
+export function runWithRedashApiKey<T>(apiKey: string | undefined, fn: () => T): T {
+  return redashApiKeyStorage.run(apiKey, fn);
+}
+
+/**
+ * Returns the Redash API key bound for the currently executing request
+ * (via `runWithRedashApiKey`), or `undefined` if none is bound (e.g. in
+ * stdio mode, or an HTTP request that didn't send an Authorization header).
+ */
+export function getRequestRedashApiKey(): string | undefined {
+  return redashApiKeyStorage.getStore();
+}
+
+/**
+ * Extracts a bearer/API token from the raw value of an HTTP `Authorization`
+ * header.
+ *
+ * Accepted formats:
+ *   - `Bearer <token>`  (common convention used by many MCP/HTTP clients)
+ *   - `Key <token>`     (Redash's own scheme, in case a client mirrors it)
+ *   - `<token>`         (raw token, no scheme prefix)
+ *
+ * The returned token is the raw Redash personal access token/API key. It is
+ * the caller's responsibility to prefix it with `Key ` again before sending
+ * it to Redash (Redash's own convention), see RedashClient.
+ *
+ * Never logs the header value; only returns it.
+ */
+export function extractApiKeyFromAuthorizationHeader(
+  headerValue: string | string[] | undefined
+): string | undefined {
+  if (!headerValue) {
+    return undefined;
+  }
+
+  const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+  const trimmed = raw?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const schemeMatch = trimmed.match(/^(Bearer|Key)\s+(.+)$/i);
+  const token = schemeMatch ? schemeMatch[2].trim() : trimmed;
+
+  return token || undefined;
+}

--- a/src/requestAuth.ts
+++ b/src/requestAuth.ts
@@ -40,7 +40,13 @@ export function getRequestRedashApiKey(): string | undefined {
  * Accepted formats:
  *   - `Bearer <token>`  (common convention used by many MCP/HTTP clients)
  *   - `Key <token>`     (Redash's own scheme, in case a client mirrors it)
- *   - `<token>`         (raw token, no scheme prefix)
+ *   - `<token>`         (raw token, no scheme prefix, no internal whitespace)
+ *
+ * Any other scheme (e.g. `Basic ...`, `Digest ...`) - or any value that
+ * contains whitespace but isn't a recognized `Bearer`/`Key` prefix - is
+ * rejected (returns `undefined`) rather than being silently treated as a raw
+ * token. This keeps the boundary between "Redash API key" and "some other
+ * kind of credential" explicit.
  *
  * The returned token is the raw Redash personal access token/API key. It is
  * the caller's responsibility to prefix it with `Key ` again before sending
@@ -62,7 +68,24 @@ export function extractApiKeyFromAuthorizationHeader(
   }
 
   const schemeMatch = trimmed.match(/^(Bearer|Key)\s+(.+)$/i);
-  const token = schemeMatch ? schemeMatch[2].trim() : trimmed;
+  if (schemeMatch) {
+    const token = schemeMatch[2].trim();
+    return token || undefined;
+  }
 
-  return token || undefined;
+  // A bare `Bearer` or `Key` with no token after it is a malformed scheme
+  // usage, not a valid raw token - reject it rather than treating the
+  // literal word as the API key.
+  if (/^(Bearer|Key)$/i.test(trimmed)) {
+    return undefined;
+  }
+
+  // No recognized scheme prefix. Only accept this as a raw token if it has
+  // no internal whitespace - anything with whitespace (e.g. `Basic <blob>`)
+  // is an unsupported/unrecognized scheme and must be rejected outright.
+  if (/\s/.test(trimmed)) {
+    return undefined;
+  }
+
+  return trimmed;
 }

--- a/src/requestAuth.ts
+++ b/src/requestAuth.ts
@@ -34,19 +34,47 @@ export function getRequestRedashApiKey(): string | undefined {
 }
 
 /**
- * Extracts a bearer/API token from the raw value of an HTTP `Authorization`
- * header.
+ * Result of parsing an incoming `Authorization` header.
  *
- * Accepted formats:
+ * Callers MUST distinguish these three cases rather than collapsing them
+ * into a single `undefined`:
+ *
+ *   - `absent`:  no `Authorization` header was supplied at all. It is safe
+ *                to fall back to the static `REDASH_API_KEY` (this is the
+ *                stdio-mode / header-less HTTP-mode behavior).
+ *   - `valid`:   a supported scheme was used and a token was extracted. Use
+ *                `apiKey` for this request; never fall back to the static
+ *                key.
+ *   - `invalid`: an `Authorization` header was supplied, but it used an
+ *                unsupported scheme or was otherwise malformed (e.g.
+ *                `Basic ...`, `Digest ...`, an empty `Bearer`). The request
+ *                MUST be rejected. Falling back to the static
+ *                `REDASH_API_KEY` here would turn a rejected/unsupported
+ *                client credential into unintended access via the shared
+ *                service-account key.
+ */
+export type AuthorizationHeaderResult =
+  | { status: "absent" }
+  | { status: "valid"; apiKey: string }
+  | { status: "invalid"; reason: string };
+
+/**
+ * Parses the raw value of an HTTP `Authorization` header and extracts a
+ * Redash API key from it, while preserving the distinction between "no
+ * header was sent" and "a header was sent but rejected" - see
+ * {@link AuthorizationHeaderResult}.
+ *
+ * Accepted formats (result: `valid`):
  *   - `Bearer <token>`  (common convention used by many MCP/HTTP clients)
  *   - `Key <token>`     (Redash's own scheme, in case a client mirrors it)
  *   - `<token>`         (raw token, no scheme prefix, no internal whitespace)
  *
  * Any other scheme (e.g. `Basic ...`, `Digest ...`) - or any value that
- * contains whitespace but isn't a recognized `Bearer`/`Key` prefix - is
- * rejected (returns `undefined`) rather than being silently treated as a raw
- * token. This keeps the boundary between "Redash API key" and "some other
- * kind of credential" explicit.
+ * contains whitespace but isn't a recognized `Bearer`/`Key` prefix, or a
+ * bare `Bearer`/`Key` with no token - is rejected (result: `invalid`) rather
+ * than being silently treated as a raw token or as "no credential supplied".
+ * This keeps the boundary between "Redash API key" and "some other kind of
+ * credential" explicit.
  *
  * The returned token is the raw Redash personal access token/API key. It is
  * the caller's responsibility to prefix it with `Key ` again before sending
@@ -56,36 +84,39 @@ export function getRequestRedashApiKey(): string | undefined {
  */
 export function extractApiKeyFromAuthorizationHeader(
   headerValue: string | string[] | undefined
-): string | undefined {
+): AuthorizationHeaderResult {
   if (!headerValue) {
-    return undefined;
+    return { status: "absent" };
   }
 
   const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
   const trimmed = raw?.trim();
   if (!trimmed) {
-    return undefined;
+    return { status: "absent" };
   }
 
   const schemeMatch = trimmed.match(/^(Bearer|Key)\s+(.+)$/i);
   if (schemeMatch) {
     const token = schemeMatch[2].trim();
-    return token || undefined;
+    if (token) {
+      return { status: "valid", apiKey: token };
+    }
+    return { status: "invalid", reason: "Bearer/Key scheme with a blank token" };
   }
 
   // A bare `Bearer` or `Key` with no token after it is a malformed scheme
   // usage, not a valid raw token - reject it rather than treating the
   // literal word as the API key.
   if (/^(Bearer|Key)$/i.test(trimmed)) {
-    return undefined;
+    return { status: "invalid", reason: "Bearer/Key scheme with no token" };
   }
 
   // No recognized scheme prefix. Only accept this as a raw token if it has
   // no internal whitespace - anything with whitespace (e.g. `Basic <blob>`)
   // is an unsupported/unrecognized scheme and must be rejected outright.
   if (/\s/.test(trimmed)) {
-    return undefined;
+    return { status: "invalid", reason: "Unsupported or unrecognized Authorization scheme" };
   }
 
-  return trimmed;
+  return { status: "valid", apiKey: trimmed };
 }

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -29,8 +29,34 @@ async function startConfiguredServer(config: ServerConfig): Promise<ServerHandle
   getRedashClient();
 
   if (config.transport === "stdio") {
+    // The stdio transport serves exactly one MCP client per process
+    // (typically a desktop app) and has no per-request Authorization header
+    // to fall back on, so REDASH_API_KEY must be a valid static credential
+    // known at startup. RedashClient itself only requires REDASH_API_KEY
+    // lazily (per outgoing request, see requestAuth.ts) to support HTTP
+    // transport's per-request tokens, so check it explicitly here to keep
+    // stdio's original fail-fast behavior.
+    if (!process.env.REDASH_API_KEY) {
+      throw new Error(
+        "REDASH_API_KEY must be provided in .env file (required for the stdio transport)."
+      );
+    }
+
     const { startStdioServer } = await import("./index.js");
     return await startStdioServer();
+  }
+
+  // In HTTP transport mode, each incoming request is expected to carry its
+  // own personal Redash API token in its `Authorization` header (see
+  // README's "Streamable HTTP Transport" section), so REDASH_API_KEY is
+  // optional here - it only serves as a fallback for requests that don't
+  // send one.
+  if (!process.env.REDASH_API_KEY) {
+    logger.warning(
+      "REDASH_API_KEY is not set. Running in HTTP transport mode without a static " +
+      "fallback key - every incoming MCP request must supply its own Redash API token via " +
+      "the `Authorization` header, or it will be rejected."
+    );
   }
 
   const { startHttpServer } = await import("./httpServer.js");


### PR DESCRIPTION
## Summary

Builds on #63 (Streamable HTTP transport) and #62 (base) and adds per-request authentication: instead of a static `REDASH_API_KEY` set once at startup, the server now reads the Redash API token from each request's `Authorization` header (`Bearer`/`Key`/raw) and uses it for that request's Redash API calls.

## Why

Redash's REST API is stateless — every call carries its own token. A statically configured process forces all users to share one token or run one process per user. This lets a single HTTP process per Redash instance serve many users, each with their own token, with no process-per-user overhead.

## Changes

- New `src/requestAuth.ts`: `AsyncLocalStorage`-based context binding the token to the current request.
- `redashClient.ts`: Axios interceptor prefers the per-request token, falls back to the static key, errors clearly if neither is set. `REDASH_API_KEY` no longer required at construction.
- `httpServer.ts`: extracts `Authorization` per `POST /mcp` request and binds it for that request's handling.
- `cli.ts`: `REDASH_API_KEY` mandatory only for stdio (default); optional fallback in HTTP mode.
- `REDASH_URL` stays static per process, as before.

Fully backward-compatible with existing stdio usage.

## Testing

Updated/added unit tests + a new httpServer e2e test verifying two clients with different tokens stay isolated. 141 tests pass, `tsc` clean. Manually smoke-tested against a live Redash instance (list/query/execute/dashboard creation, correctly attributed per user) plus a negative test with an invalid token.

---

*Disclosure: this change was developed with AI assistance (Claude). It has been reviewed and tested by a human against a live Redash instance before submission; please review accordingly.*