### PR TITLE
fix: handle http->https redirects without dropping auth or converting POST to GET

### DIFF
--- a/src/__tests__/redashClient.test.ts
+++ b/src/__tests__/redashClient.test.ts
@@ -38,8 +38,14 @@ describe('RedashClient', () => {
       get: jest.fn(),
       post: jest.fn(),
       delete: jest.fn(),
+      request: jest.fn(),
       defaults: {
         headers: {},
+      },
+      interceptors: {
+        response: {
+          use: jest.fn(),
+        },
       },
     };
 
@@ -75,6 +81,7 @@ describe('RedashClient', () => {
           'Content-Type': 'application/json',
         },
         timeout: 30000,
+        maxRedirects: 0,
       });
     });
 
@@ -119,6 +126,98 @@ describe('RedashClient', () => {
       const callArgs = mockedAxios.create.mock.calls[0]?.[0];
       expect(callArgs?.headers).toBeDefined();
       expect((callArgs?.headers as any)?.Authorization).toBe('Key test-api-key');
+    });
+  });
+
+  describe('redirect handling', () => {
+    const getRedirectHandler = (): ((error: any) => Promise<any>) => {
+      const useCall = mockAxiosInstance.interceptors.response.use.mock.calls[0];
+      return useCall[1];
+    };
+
+    beforeEach(() => {
+      process.env.REDASH_URL = 'http://redash.example.com';
+      mockedAxios.create.mockClear();
+      mockAxiosInstance.interceptors.response.use.mockClear();
+      client = new RedashClient();
+    });
+
+    it('should register a response interceptor', () => {
+      expect(mockAxiosInstance.interceptors.response.use).toHaveBeenCalledWith(
+        undefined,
+        expect.any(Function)
+      );
+    });
+
+    it('should upgrade the base URL and retry on a same-host http to https redirect', async () => {
+      const handler = getRedirectHandler();
+      mockAxiosInstance.request.mockResolvedValue({ data: 'ok' });
+
+      const error = {
+        response: {
+          status: 301,
+          headers: { location: 'https://redash.example.com/' },
+        },
+        config: { url: '/api/queries', method: 'post', data: { a: 1 } },
+      };
+
+      const result = await handler(error);
+
+      expect(result).toEqual({ data: 'ok' });
+      expect(mockAxiosInstance.defaults.baseURL).toBe('https://redash.example.com');
+      expect(mockAxiosInstance.request).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: '/api/queries',
+          method: 'post',
+          data: { a: 1 },
+          baseURL: 'https://redash.example.com',
+          __redirectRetried: true,
+        })
+      );
+    });
+
+    it('should not retry a request that was already retried', async () => {
+      const handler = getRedirectHandler();
+
+      const error = {
+        response: {
+          status: 301,
+          headers: { location: 'https://redash.example.com/' },
+        },
+        config: { url: '/api/queries', __redirectRetried: true },
+      };
+
+      await expect(handler(error)).rejects.toBe(error);
+      expect(mockAxiosInstance.request).not.toHaveBeenCalled();
+    });
+
+    it('should reject with a clear error on a cross-host redirect', async () => {
+      const handler = getRedirectHandler();
+
+      const error = {
+        response: {
+          status: 302,
+          headers: { location: 'https://other.example.com/' },
+        },
+        config: { url: '/api/queries' },
+      };
+
+      await expect(handler(error)).rejects.toThrow(
+        /redirect \(302\).*Update REDASH_URL/
+      );
+      expect(mockAxiosInstance.request).not.toHaveBeenCalled();
+    });
+
+    it('should pass through non-redirect errors unchanged', async () => {
+      const handler = getRedirectHandler();
+
+      const error = {
+        response: { status: 500, headers: {} },
+        config: { url: '/api/queries' },
+      };
+
+      await expect(handler(error)).rejects.toBe(error);
+      expect(mockAxiosInstance.request).not.toHaveBeenCalled();
     });
   });
 

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -292,7 +292,8 @@ export class RedashClient {
         ...defaultHeaders,
         ...extraHeaders,
       },
-      timeout: parseInt(process.env.REDASH_TIMEOUT || '30000')
+      timeout: parseInt(process.env.REDASH_TIMEOUT || '30000'),
+      maxRedirects: 0
     };
 
     const socksProxy = process.env.REDASH_SOCKS_PROXY;
@@ -303,6 +304,46 @@ export class RedashClient {
     }
 
     this.client = axios.create(axiosConfig);
+    this.client?.interceptors?.response.use(
+      undefined,
+      (error) => this.handleRedirectError(error)
+    );
+  }
+
+  // Handle redirect responses ourselves (maxRedirects is 0). Letting axios
+  // follow a cross-protocol redirect strips the Authorization header
+  // (follow-redirects >= 1.15.6) and turns a 301'd POST into a GET, so an
+  // http:// REDASH_URL behind an https-redirecting proxy silently breaks.
+  // Instead, upgrade a same-host http -> https base URL once and retry the
+  // request intact.
+  private handleRedirectError(error: any): Promise<any> {
+    const status = error?.response?.status;
+    const location = error?.response?.headers?.location;
+    const config = error?.config;
+
+    if (!config || config.__redirectRetried || !location || ![301, 302, 307, 308].includes(status)) {
+      return Promise.reject(error);
+    }
+
+    let base: URL;
+    let target: URL;
+    try {
+      base = new URL(this.baseUrl);
+      target = new URL(location, this.baseUrl);
+    } catch {
+      return Promise.reject(error);
+    }
+
+    if (base.protocol === 'http:' && target.protocol === 'https:' && target.hostname === base.hostname) {
+      base.protocol = 'https:';
+      const upgraded = base.toString().replace(/\/+$/, '');
+      logger.warning(`REDASH_URL uses http:// but the server redirects to https://; retrying against ${upgraded}. Update REDASH_URL to https:// to avoid the extra round-trip.`);
+      this.baseUrl = upgraded;
+      this.client.defaults.baseURL = upgraded;
+      return this.client.request({ ...config, baseURL: upgraded, __redirectRetried: true });
+    }
+
+    return Promise.reject(new Error(`Redash responded with a redirect (${status}) to ${target.toString()}. Update REDASH_URL to point at the final address.`));
   }
 
   // Parse extra headers from env var `REDASH_EXTRA_HEADERS`.


### PR DESCRIPTION
## Problem

When `REDASH_URL` uses `http://` and the Redash instance sits behind a proxy/load balancer that 301-redirects to `https://` (a very common setup), every API call silently breaks:

- axios delegates redirects to `follow-redirects`, which (since 1.15.6, CVE-2024-28849) **strips the `Authorization` header on any cross-protocol redirect** — including http->https on the same host. Requests arrive at Redash unauthenticated and get the login page or a 401.
- A 301/302 on a **POST is converted to a GET and the body is dropped**, so `execute-query`, `create-query`, etc. break even where auth isn't needed.

The failure is confusing to debug because the same URL works fine in a browser.

## Fix

`RedashClient` now sets `maxRedirects: 0` and handles redirects itself via a response interceptor:

- A redirect that is a **same-host http->https upgrade** logs a warning, permanently upgrades the client's base URL, and retries the original request intact — same method, headers (including `Authorization`), and body. Only one extra round-trip for the first request; everything after goes straight to `https`.
- Any **other redirect** rejects with a clear error telling the user to update `REDASH_URL` to the final address, instead of silently returning login-page HTML.

A retry guard (`__redirectRetried`) prevents loops.

## Tests

- `should create axios instance with correct config` updated for `maxRedirects: 0`.
- New `redirect handling` suite: upgrade-and-retry on same-host http->https, no double retry, clear error on cross-host redirects, non-redirect errors passed through untouched.
- Full suite: 8 suites / 123 tests passing, `tsc --noEmit` clean.