### PR TITLE
fix: add type-safe schedule schema with day_of_week default

### DIFF
--- a/src/__tests__/scheduleSchema.test.ts
+++ b/src/__tests__/scheduleSchema.test.ts
@@ -1,0 +1,77 @@
+import { z } from 'zod';
+
+// Reproduce the schedule schema defined in index.ts
+const scheduleSchema = z.object({
+  interval: z.number().nullable(),
+  time: z.string().nullable().optional(),
+  until: z.string().nullable().optional(),
+  day_of_week: z.string().nullable().default(null),
+  disabled: z.boolean().optional(),
+}).optional().nullable();
+
+describe('scheduleSchema', () => {
+  it('should default day_of_week to null when omitted', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
+    });
+    expect(result).toEqual({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
+      day_of_week: null,
+    });
+  });
+
+  it('should preserve day_of_week when explicitly provided', () => {
+    const result = scheduleSchema.parse({
+      interval: 604800,
+      time: '06:00',
+      day_of_week: 'Monday',
+    });
+    expect(result).toMatchObject({
+      interval: 604800,
+      day_of_week: 'Monday',
+    });
+  });
+
+  it('should preserve day_of_week as null when explicitly set to null', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      day_of_week: null,
+    });
+    expect(result).toMatchObject({
+      interval: 86400,
+      day_of_week: null,
+    });
+  });
+
+  it('should return null for null input', () => {
+    const result = scheduleSchema.parse(null);
+    expect(result).toBeNull();
+  });
+
+  it('should return undefined for undefined input', () => {
+    const result = scheduleSchema.parse(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should accept disabled field', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      disabled: true,
+    });
+    expect(result).toMatchObject({
+      interval: 86400,
+      day_of_week: null,
+      disabled: true,
+    });
+  });
+
+  it('should reject invalid interval type', () => {
+    expect(() => scheduleSchema.parse({
+      interval: 'daily',
+    })).toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,17 @@ async function getQuery(params: z.infer<typeof getQuerySchema>) {
   }
 }
 
+// Schedule schema with day_of_week defaulting to null
+// day_of_week uses full English names: "Monday", "Tuesday", etc.
+// interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
+const scheduleSchema = z.object({
+  interval: z.number().nullable(),
+  time: z.string().nullable().optional(),
+  until: z.string().nullable().optional(),
+  day_of_week: z.string().nullable().default(null),
+  disabled: z.boolean().optional(),
+}).optional().nullable();
+
 // Tool: create_query
 const createQuerySchema = z.object({
   name: z.string(),
@@ -100,7 +111,7 @@ const createQuerySchema = z.object({
   query: z.string(),
   description: z.string().optional(),
   options: z.record(z.any()).optional(),
-  schedule: z.record(z.any()).optional(),
+  schedule: scheduleSchema,
   tags: z.array(z.string()).optional()
 });
 
@@ -153,7 +164,7 @@ const updateQuerySchema = z.object({
   query: z.string().optional(),
   description: z.string().optional(),
   options: z.record(z.any()).optional(),
-  schedule: z.record(z.any()).optional(),
+  schedule: scheduleSchema,
   tags: z.array(z.string()).optional(),
   is_archived: z.boolean().optional(),
   is_draft: z.boolean().optional()

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -21,6 +21,17 @@ export interface RedashQuery {
   visualizations: RedashVisualization[];
 }
 
+// Schedule interface for Redash queries
+// day_of_week uses full English names: "Monday", "Tuesday", etc.
+// interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
+export interface QuerySchedule {
+  interval: number | null;
+  time?: string | null;
+  until?: string | null;
+  day_of_week: string | null;
+  disabled?: boolean;
+}
+
 // New interfaces for query creation and update
 export interface CreateQueryRequest {
   name: string;
@@ -28,7 +39,7 @@ export interface CreateQueryRequest {
   query: string;
   description?: string;
   options?: any;
-  schedule?: any;
+  schedule?: QuerySchedule | null;
   tags?: string[];
 }
 
@@ -38,7 +49,7 @@ export interface UpdateQueryRequest {
   query?: string;
   description?: string;
   options?: any;
-  schedule?: any;
+  schedule?: QuerySchedule | null;
   tags?: string[];
   is_archived?: boolean;
   is_draft?: boolean;


### PR DESCRIPTION
## Summary

- Replace `z.any()` / `any` for the `schedule` parameter in `create_query` and `update_query` with a proper Zod schema (`scheduleSchema`) and TypeScript interface (`QuerySchedule`)
- `day_of_week` defaults to `null` via Zod's `.default(null)`, so callers no longer need to include it explicitly
- Interface fields (`interval`, `time`, `until`, `day_of_week`, `disabled`) are based on the [Redash source code](https://github.com/getredash/redash/blob/master/redash/models/__init__.py)

## Why

When `day_of_week` is missing from the schedule JSON stored in Redash's DB, the scheduler (`refresh_queries` / `outdated_queries`) can break (ref: [getredash/redash#4163](https://github.com/getredash/redash/pull/4163)). Previously, `schedule` accepted `any`, so it was easy to create queries with incomplete schedule objects missing `day_of_week`.

## Test plan

- [x] `npm run build` passes
- [ ] Manually verify: call `update_query` with a schedule omitting `day_of_week` → confirm `day_of_week: null` is included in the Redash API request

---

*Disclosure: this change was developed with AI assistance (Claude). It has been reviewed and tested by a human before submission.*