### PR TITLE
fix: add type-safe schedule schema with day_of_week default

### DIFF
--- a/src/__tests__/scheduleSchema.test.ts
+++ b/src/__tests__/scheduleSchema.test.ts
@@ -1,0 +1,74 @@
+import { scheduleSchema } from '../index.js';
+
+describe('scheduleSchema', () => {
+  it('should default day_of_week to null when omitted', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
+    });
+    expect(result).toEqual({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
+      day_of_week: null,
+    });
+  });
+
+  it('should preserve day_of_week when explicitly provided', () => {
+    const result = scheduleSchema.parse({
+      interval: 604800,
+      time: '06:00',
+      day_of_week: 'Monday',
+    });
+    expect(result).toMatchObject({
+      interval: 604800,
+      day_of_week: 'Monday',
+    });
+  });
+
+  it('should preserve day_of_week as null when explicitly set to null', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      day_of_week: null,
+    });
+    expect(result).toMatchObject({
+      interval: 86400,
+      day_of_week: null,
+    });
+  });
+
+  it('should return null for null input', () => {
+    const result = scheduleSchema.parse(null);
+    expect(result).toBeNull();
+  });
+
+  it('should return undefined for undefined input', () => {
+    const result = scheduleSchema.parse(undefined);
+    expect(result).toBeUndefined();
+  });
+
+  it('should accept disabled field', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      disabled: true,
+    });
+    expect(result).toMatchObject({
+      interval: 86400,
+      day_of_week: null,
+      disabled: true,
+    });
+  });
+
+  it('should reject invalid interval type', () => {
+    expect(() => scheduleSchema.parse({
+      interval: 'daily',
+    })).toThrow();
+  });
+
+  it('should require interval', () => {
+    expect(() => scheduleSchema.parse({
+      time: '01:15',
+    })).toThrow();
+  });
+});

--- a/src/__tests__/scheduleSchema.test.ts
+++ b/src/__tests__/scheduleSchema.test.ts
@@ -1,4 +1,4 @@
-import { scheduleSchema } from '../index.js';
+import { scheduleSchema } from '../schedule.js';
 
 describe('scheduleSchema', () => {
   it('should default day_of_week to null when omitted', () => {

--- a/src/__tests__/scheduleSchema.test.ts
+++ b/src/__tests__/scheduleSchema.test.ts
@@ -1,16 +1,14 @@
 import { scheduleSchema } from '../schedule.js';
 
 describe('scheduleSchema', () => {
-  it('should default day_of_week to null when omitted', () => {
+  it('should default day_of_week, time, and until to null when omitted', () => {
     const result = scheduleSchema.parse({
       interval: 86400,
-      time: '01:15',
-      until: '2026-08-14',
     });
     expect(result).toEqual({
       interval: 86400,
-      time: '01:15',
-      until: '2026-08-14',
+      time: null,
+      until: null,
       day_of_week: null,
     });
   });
@@ -27,6 +25,21 @@ describe('scheduleSchema', () => {
     });
   });
 
+  it('should accept all valid day_of_week values', () => {
+    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    for (const day of days) {
+      const result = scheduleSchema.parse({ interval: 604800, day_of_week: day });
+      expect(result).toMatchObject({ day_of_week: day });
+    }
+  });
+
+  it('should reject invalid day_of_week string', () => {
+    expect(() => scheduleSchema.parse({
+      interval: 604800,
+      day_of_week: 'monday',
+    })).toThrow();
+  });
+
   it('should preserve day_of_week as null when explicitly set to null', () => {
     const result = scheduleSchema.parse({
       interval: 86400,
@@ -34,6 +47,20 @@ describe('scheduleSchema', () => {
     });
     expect(result).toMatchObject({
       interval: 86400,
+      day_of_week: null,
+    });
+  });
+
+  it('should preserve time and until when provided', () => {
+    const result = scheduleSchema.parse({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
+    });
+    expect(result).toEqual({
+      interval: 86400,
+      time: '01:15',
+      until: '2026-08-14',
       day_of_week: null,
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,6 +93,17 @@ async function getQuery(params: z.infer<typeof getQuerySchema>) {
   }
 }
 
+// Schedule schema with day_of_week defaulting to null
+// day_of_week uses full English names: "Monday", "Tuesday", etc.
+// interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
+export const scheduleSchema = z.object({
+  interval: z.number(),
+  time: z.string().nullable().optional(),
+  until: z.string().nullable().optional(),
+  day_of_week: z.string().nullable().default(null),
+  disabled: z.boolean().optional(),
+}).optional().nullable();
+
 // Tool: create_query
 const createQuerySchema = z.object({
   name: z.string(),
@@ -100,7 +111,7 @@ const createQuerySchema = z.object({
   query: z.string(),
   description: z.string().optional(),
   options: z.record(z.any()).optional(),
-  schedule: z.record(z.any()).optional(),
+  schedule: scheduleSchema,
   tags: z.array(z.string()).optional()
 });
 
@@ -153,7 +164,7 @@ const updateQuerySchema = z.object({
   query: z.string().optional(),
   description: z.string().optional(),
   options: z.record(z.any()).optional(),
-  schedule: z.record(z.any()).optional(),
+  schedule: scheduleSchema,
   tags: z.array(z.string()).optional(),
   is_archived: z.boolean().optional(),
   is_draft: z.boolean().optional()

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { buildParameterizedExecutionParameters, ParameterizedExecutionError } fr
 import { mergeDeep } from "./utils.js";
 import { buildWidgetLayoutOptions, dashboardGridDefaults, summarizeWidgetLayout, widgetLayoutEntrySchema, widgetPositionSchema } from "./widgetLayout.js";
 import { logger, LogLevel } from "./logger.js";
+import { scheduleSchema } from './schedule.js';
 
 // Load environment variables
 dotenv.config();
@@ -92,8 +93,6 @@ async function getQuery(params: z.infer<typeof getQuerySchema>) {
     };
   }
 }
-
-import { scheduleSchema } from './schedule.js';
 
 // Tool: create_query
 const createQuerySchema = z.object({

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,16 +93,7 @@ async function getQuery(params: z.infer<typeof getQuerySchema>) {
   }
 }
 
-// Schedule schema with day_of_week defaulting to null
-// day_of_week uses full English names: "Monday", "Tuesday", etc.
-// interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
-export const scheduleSchema = z.object({
-  interval: z.number(),
-  time: z.string().nullable().optional(),
-  until: z.string().nullable().optional(),
-  day_of_week: z.string().nullable().default(null),
-  disabled: z.boolean().optional(),
-}).optional().nullable();
+import { scheduleSchema } from './schedule.js';
 
 // Tool: create_query
 const createQuerySchema = z.object({

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+// Schedule schema with day_of_week defaulting to null
+// day_of_week uses full English names: "Monday", "Tuesday", etc.
+// interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
+export const scheduleSchema = z.object({
+  interval: z.number(),
+  time: z.string().nullable().optional(),
+  until: z.string().nullable().optional(),
+  day_of_week: z.string().nullable().default(null),
+  disabled: z.boolean().optional(),
+}).optional().nullable();

--- a/src/schedule.ts
+++ b/src/schedule.ts
@@ -1,12 +1,18 @@
 import { z } from 'zod';
 
-// Schedule schema with day_of_week defaulting to null
-// day_of_week uses full English names: "Monday", "Tuesday", etc.
+const dayOfWeekEnum = z.enum([
+  'Sunday', 'Monday', 'Tuesday', 'Wednesday',
+  'Thursday', 'Friday', 'Saturday',
+]);
+
+// Schedule schema with day_of_week, time, and until defaulting to null.
+// Redash's scheduler indexes these keys directly, so they must always
+// be present in the stored JSON (even as null).
 // interval is in seconds (e.g., 86400 = daily, 604800 = weekly)
 export const scheduleSchema = z.object({
   interval: z.number(),
-  time: z.string().nullable().optional(),
-  until: z.string().nullable().optional(),
-  day_of_week: z.string().nullable().default(null),
+  time: z.string().nullable().default(null),
+  until: z.string().nullable().default(null),
+  day_of_week: dayOfWeekEnum.nullable().default(null),
   disabled: z.boolean().optional(),
 }).optional().nullable();


### PR DESCRIPTION
## Summary

- Add a Zod schema (`scheduleSchema`) for the `schedule` parameter in `create_query` and `update_query`, replacing `z.record(z.any())`
- `day_of_week` defaults to `null` via `.default(null)`, so callers no longer need to include it explicitly
- Schema fields (`interval`, `time`, `until`, `day_of_week`, `disabled`) are based on the [Redash source code](https://github.com/getredash/redash/blob/master/redash/models/__init__.py)
- Extract `scheduleSchema` to `src/schedule.ts` so tests can import it without triggering `RedashClient` initialization

## Why

When `day_of_week` is missing from the schedule JSON stored in Redash's DB, the scheduler (`refresh_queries` / `outdated_queries`) can break. This was reported and fixed in the latest Redash ([getredash/redash#4163](https://github.com/getredash/redash/pull/4163)), but older self-hosted Redash instances that haven't been upgraded are still affected. Since many users run older versions, it's better to prevent malformed schedule objects at the MCP layer rather than relying on the Redash server to handle them gracefully.

Previously, `schedule` accepted any record (`z.record(z.any())`), so it was easy to create queries with incomplete schedule objects missing `day_of_week`.

## Test plan

- [x] `npm run build` passes
- [x] 8 unit tests pass (`scheduleSchema.test.ts`): default value, explicit value, null/undefined, disabled, invalid type, required interval
- [x] Tests pass without `REDASH_URL` / `REDASH_API_KEY` env vars (no side-effect imports)
- [x] Manually verify: call `update_query` with a schedule omitting `day_of_week` → confirm `day_of_week: null` is included in the Redash API request

---

*Disclosure: this change was developed with AI assistance (Claude). It has been reviewed and tested by a human before submission.*