### PR TITLE
Make npm publishing single-path and rerunnable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -39,9 +39,3 @@ jobs:
       - name: Test
         if: steps.tagpr.outputs.tag != ''
         run: npm test
-
-      - name: Publish to npm
-        if: steps.tagpr.outputs.tag != ''
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- publish npm packages only from the tag-triggered release workflow
- remove the duplicate publish attempt from the tagpr workflow
- allow the release workflow to be dispatched manually for safe recovery of an existing tag

## Why

The v0.0.14 tag run exposed two independent publish attempts for the same version. Both currently fail because the npm credential needs to be refreshed, but after authentication is restored the duplicate path would create a race and make one workflow fail even when the release succeeds.

With this change, `tagpr` owns versioning and tag creation, while `release.yml` is the single npm publishing path. The v0.0.14 tag can be retried explicitly after the npm credential is repaired.

## Validation

- both workflow files parse as valid YAML
- the normal repository test workflow will run on this PR
