### PR TITLE
Publish npm releases with trusted OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,17 +5,29 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      release_ref:
+        description: Git tag or commit to publish
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
       
       - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
           
       - name: Install dependencies
         run: npm ci
@@ -28,5 +40,3 @@ jobs:
         
       - name: Publish to npm
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- grant the release workflow GitHub's OIDC permission and remove the long-lived npm token
- run releases on Node.js 24, which includes an npm version compatible with trusted publishing
- accept an explicit tag or commit for manual recovery runs while preserving tag-triggered releases

## Why

The v0.0.14 publish failed because the stored npm token is no longer accepted. npm's trusted publishing flow uses short-lived OIDC credentials instead and requires `id-token: write`, Node.js 22.14 or newer, and npm 11.5.1 or newer.

The explicit `release_ref` input lets us run the current secure workflow while checking out the existing v0.0.14 tag, so the published artifact still matches the GitHub release.

Reference: https://docs.npmjs.com/trusted-publishers/

## Validation

- `release.yml` parses as valid YAML
- whitespace validation passes
- the repository's Node.js 20 test workflow will run on this PR
