### PR TITLE
Preserve the CLI entry with npm 11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           package-manager-cache: false
+
+      - name: Normalize package metadata
+        run: npm pkg fix
           
       - name: Install dependencies
         run: npm ci

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "type": "module",
   "bin": {
-    "redash-mcp": "./dist/cli.js"
+    "redash-mcp": "dist/cli.js"
   },
   "main": "./dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary

- normalize the package `bin` path for npm 11
- run `npm pkg fix` in the release job so recovery publishes of older tags receive the same deterministic normalization

## Why

The v0.0.14 OIDC test run showed npm 11 removing the `redash-mcp` CLI entry during `npm publish`. npm's own `npm pkg fix` changes the path from `./dist/cli.js` to `dist/cli.js`; after that change, the warning disappears and the executable remains in the package.

## Validation

- `npm run build`
- `npm test -- --runInBand` (119 tests)
- `npm publish --dry-run --access public` with Node.js 24 / npm 11.6.2
- no package metadata correction warning in the final dry run
