### PR TITLE
fix: normalize repository metadata before npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,11 @@ jobs:
           package-manager-cache: false
 
       - name: Normalize package metadata
-        run: npm pkg fix
+        run: |
+          npm pkg fix
+          npm pkg set \
+            repository.type=git \
+            repository.url=https://github.com/suthio/redash-mcp
           
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## What changed

- Normalize the package metadata with `npm pkg fix`.
- Explicitly set the GitHub repository type and URL before publishing.

## Why

The v0.0.14 Trusted Publishing run successfully created and signed its provenance, but npm rejected the package because the v0.0.14 tag's `package.json` did not include `repository.url`.

## Impact

Manual release runs can now publish existing tags while satisfying npm's provenance repository validation.

## Validation

- `git diff --check`
- The v0.0.14 release run passed install, build, and all 119 tests before reaching npm provenance validation.
