### PR TITLE
Correct the ad hoc query tool description

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2177,7 +2177,7 @@ export const toolDefinitions = [
   defineTool("get_visualization", "Get details of a specific visualization", getVisualization, getVisualizationSchema),
   defineTool(
     "execute_adhoc_query",
-    "Execute an ad-hoc query without saving it to Redash. Creates a temporary query that is automatically deleted after execution.",
+    "Execute a one-off query without saving it to Redash.",
     executeAdhocQuery,
     executeAdhocQuerySchema,
   ),


### PR DESCRIPTION
`execute_adhoc_query` posts SQL directly to `/api/query_results`. It does not create a saved query, and there is no temporary query to delete afterward.

The old tool description said a temporary query was created and automatically deleted. This replaces that claim with the behavior the implementation provides: run a one-off query without saving it to Redash. Runtime behavior is unchanged.