### PR TITLE
Prevent OOM when reading large BigQuery schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,32 @@ Published images are signed with keyless cosign.
 - `execute_adhoc_query`: Execute an ad-hoc query without saving it to Redash
 - `get_query_results_csv`: Get query results in CSV format (supports optional refresh for latest data)
 
+### Schema Discovery
+- `get_schema`: Get the schema of a data source, paginated by table
+
+Use `get_schema` when an MCP client needs table and column names for writing a
+query. A caller can request a small page, inspect `hasMore`, and follow `nextPage`
+without loading the entire warehouse schema into this MCP server. For BigQuery,
+a configured location also allows the server to fetch only the requested tables.
+
+| Data source | How one page is read | Why |
+| --- | --- | --- |
+| BigQuery (`bigquery` and `bigquery_gce`) | Read the connection's configured `location` from `/api/data_sources/{dataSourceId}`, then query that region's `INFORMATION_SCHEMA` for only the requested tables. If the API does not expose a valid location or the metadata query fails, stream the schema endpoint instead. | A configured location lets Redash avoid materializing its complete cached schema for very large BigQuery projects. The fallback keeps `get_schema` usable for API keys that cannot read connection options. |
+| Query Results (`results`) | Static schema discovery is unavailable. Use `execute_adhoc_query` with tables such as `query_123` or `cached_query_123`. | Query Results creates its SQLite tables dynamically from saved query results, so there is no fixed table or column list for `get_schema` to return. |
+| Other schema-capable data sources | Stream `/api/data_sources/{dataSourceId}/schema`, parse tables incrementally, and stop the HTTP transfer after the requested page plus one table. | The MCP server retains only the requested page instead of the complete Redash response. |
+
+Parameters: `dataSourceId` (required), `page` (default 1), `pageSize` (default 25,
+max 100), and `search` (optional case-insensitive substring match on table names;
+pagination applies to the filtered set). The response includes `hasMore` and
+`nextPage` for iterating through large schemas.
+
+For example, to inspect tables in a BigQuery dataset named `analytics_public`
+on data source `7`, call `get_schema` with
+`{"dataSourceId":7,"pageSize":10,"search":"analytics_public."}`. `pageSize`
+limits the number of tables in one response; it does not split the columns or
+nested field paths within a table. A wide table such as a GA4 event export is
+therefore returned with all of its field paths even when `pageSize` is `1`.
+
 ### Dashboard Management
 - `list_dashboards`: List all available dashboards
 - `get_dashboard`: Get dashboard details and visualizations

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
+// ESM-only packages that must be transpiled to CJS for Jest.
+const esmOnlyDeps = ['stream-json', 'stream-chain'];
+
 export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
@@ -10,9 +13,26 @@ export default {
       'ts-jest',
       {
         useESM: true,
+        // ts-jest's ESM mode overrides `module`, which drops moduleResolution
+        // to Node10 and breaks NodeNext package "exports" lookups (stream-json
+        // subpath imports); 'bundler' restores exports-map resolution.
+        tsconfig: { moduleResolution: 'bundler' },
+      },
+    ],
+    [`[\\\\/](${esmOnlyDeps.join('|')})[\\\\/].*\\.js$`]: [
+      'ts-jest',
+      {
+        isolatedModules: true,
+        tsconfig: { allowJs: true, checkJs: false, module: 'commonjs' },
       },
     ],
   },
+  // Ignore node_modules except paths that contain an ESM-only dep anywhere
+  // after them — position-independent, so it works for both direct layouts
+  // and pnpm's node_modules/.pnpm/<pkg>@<ver>/node_modules/<pkg> paths.
+  transformIgnorePatterns: [
+    `[\\\\/]node_modules[\\\\/](?!.*(${esmOnlyDeps.join('|')}))`,
+  ],
   setupFiles: ['<rootDir>/src/__tests__/setupEnv.ts'],
   testMatch: [
     '**/__tests__/**/*.test.ts',

--- a/package.json
+++ b/package.json
@@ -84,6 +84,8 @@
     "dotenv": "^17.4.2",
     "hono": "^4.12.33",
     "socks-proxy-agent": "^8.0.5",
+    "stream-chain": "^4.2.5",
+    "stream-json": "^3.5.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,12 @@ importers:
       socks-proxy-agent:
         specifier: ^8.0.5
         version: 8.0.5
+      stream-chain:
+        specifier: ^4.2.5
+        version: 4.2.5
+      stream-json:
+        specifier: ^3.5.0
+        version: 3.5.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -699,6 +705,9 @@ packages:
 
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
+  '@types/node@20.19.43':
+    resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
   '@types/node@22.20.1':
     resolution: {integrity: sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==}
@@ -1610,6 +1619,14 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stream-chain@4.2.5:
+    resolution: {integrity: sha512-Wtyq3bNE3ggLR0v2vftqvuhltym3WbZAkZpfIrkr5F/6vpeUmWmwTgXa16zD87gpahwJ/Qulq3zVfUlgIc0J2A==}
+    engines: {node: '>=22'}
+
+  stream-json@3.5.0:
+    resolution: {integrity: sha512-dobB7zipGW8o11PvdRljQSWuyMxifADLvoHeA4elwNWOTbZo6+BlNa+P6aCq7Y9jRiWTy2Ucu2xSv0Y2/T+/kQ==}
+    engines: {node: '>=22'}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -2019,7 +2036,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -2032,14 +2049,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -2064,7 +2081,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -2082,7 +2099,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2104,7 +2121,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit: 0.1.2
@@ -2174,7 +2191,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -2541,7 +2558,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -2557,6 +2574,10 @@ snapshots:
     dependencies:
       expect: 29.7.0
       pretty-format: 29.7.0
+
+  '@types/node@20.19.43':
+    dependencies:
+      undici-types: 6.21.0
 
   '@types/node@22.20.1':
     dependencies:
@@ -3064,7 +3085,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -3102,6 +3123,37 @@ snapshots:
       - babel-plugin-macros
       - supports-color
       - ts-node
+
+  jest-config@29.7.0(@types/node@20.19.43)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 20.19.43
+      ts-node: 10.9.2(@types/node@22.20.1)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
 
   jest-config@29.7.0(@types/node@22.20.1)(ts-node@10.9.2(@types/node@22.20.1)(typescript@5.9.3)):
     dependencies:
@@ -3158,7 +3210,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -3168,7 +3220,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3207,7 +3259,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -3242,7 +3294,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3270,7 +3322,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.3
@@ -3316,7 +3368,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3335,7 +3387,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3344,7 +3396,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -3526,7 +3578,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 22.20.1
+      '@types/node': 20.19.43
       long: 5.3.2
 
   proxy-from-env@2.1.0: {}
@@ -3602,6 +3654,12 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stream-chain@4.2.5: {}
+
+  stream-json@3.5.0:
+    dependencies:
+      stream-chain: 4.2.5
 
   string-length@4.0.2:
     dependencies:

--- a/src/__tests__/bigQuerySchema.test.ts
+++ b/src/__tests__/bigQuerySchema.test.ts
@@ -1,0 +1,132 @@
+import {
+  buildBigQuerySchemaPageQuery,
+  readBigQueryDataSourceLocation,
+  readBigQuerySchemaPage,
+} from '../bigQuerySchema.js';
+
+function resultWithRows(rows: Array<Record<string, unknown>>) {
+  return { query_result: { data: { rows } } };
+}
+
+describe('BigQuery schema pagination', () => {
+  it('builds a bounded, region-scoped metadata query', () => {
+    const query = buildBigQuerySchemaPageQuery('asia-northeast1', 2, 25);
+
+    expect(query).toContain('`region-asia-northeast1`.INFORMATION_SCHEMA.TABLES');
+    expect(query).toContain('`region-asia-northeast1`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS');
+    expect(query).toContain('LIMIT 26 OFFSET 25');
+    expect(query).toContain('WHERE page_position <= 25');
+    expect(query).toContain('JOIN page_tables AS t\n    USING (table_catalog, table_schema, table_name)');
+    expect(query).toContain('(SELECT COUNT(*) > 25 FROM numbered_tables) AS has_more');
+    expect(query).toContain('TO_JSON_STRING(ARRAY_AGG(');
+  });
+
+  it('encodes search text instead of interpolating it into SQL', () => {
+    const search = "Customer's 売上";
+    const query = buildBigQuerySchemaPageQuery('US', 1, 10, search);
+
+    expect(query).toContain('`region-us`.INFORMATION_SCHEMA.TABLES');
+    expect(query).toContain(Buffer.from(search, 'utf8').toString('hex'));
+    expect(query).not.toContain(search);
+  });
+
+  it('rejects unsafe locations and offsets', () => {
+    expect(() => buildBigQuerySchemaPageQuery('us`; DROP TABLE x', 1, 25)).toThrow(
+      'BigQuery location contained unexpected characters',
+    );
+    expect(() => buildBigQuerySchemaPageQuery('us', Number.MAX_SAFE_INTEGER, 100)).toThrow(
+      'page and pageSize produce an unsupported offset',
+    );
+  });
+
+  it.each([
+    [0, 25, 'page must be a positive integer'],
+    [1, 0, 'pageSize must be an integer between 1 and 100'],
+    [1, 1.5, 'pageSize must be an integer between 1 and 100'],
+    [1, 101, 'pageSize must be an integer between 1 and 100'],
+  ])('rejects invalid query pagination page=%p pageSize=%p', (page, pageSize, message) => {
+    expect(() => buildBigQuerySchemaPageQuery('us', page, pageSize)).toThrow(message);
+  });
+
+  it('reads and normalizes the configured BigQuery location', () => {
+    expect(readBigQueryDataSourceLocation({
+      id: 7,
+      options: { location: 'ASIA-NORTHEAST1' },
+    })).toBe('asia-northeast1');
+    expect(readBigQueryDataSourceLocation({ options: { location: 'us' } })).toBe('us');
+  });
+
+  it('returns null for a missing or unsafe configured location', () => {
+    expect(readBigQueryDataSourceLocation({ options: {} })).toBeNull();
+    expect(readBigQueryDataSourceLocation({ options: { location: 'us`' } })).toBeNull();
+    expect(readBigQueryDataSourceLocation(null)).toBeNull();
+  });
+
+  it('groups metadata rows into Redash schema tables', () => {
+    const result = readBigQuerySchemaPage(resultWithRows([
+      {
+        page_position: 1,
+        table_name: 'analytics.events',
+        table_description: 'GA4 export',
+        columns_json: JSON.stringify([
+          { name: 'event_date', type: 'STRING', description: null },
+          { name: 'event_params.key', type: 'STRING', description: 'Parameter key' },
+        ]),
+        has_more: true,
+      },
+      {
+        page_position: 2,
+        table_name: 'sales.orders',
+        table_description: null,
+        columns_json: '[]',
+        has_more: true,
+      },
+    ]), 3, 2);
+
+    expect(result).toEqual({
+      page: 3,
+      pageSize: 2,
+      hasMore: true,
+      nextPage: 4,
+      schema: [
+        {
+          name: 'analytics.events',
+          description: 'GA4 export',
+          columns: [
+            { name: 'event_date', type: 'STRING' },
+            { name: 'event_params.key', type: 'STRING', description: 'Parameter key' },
+          ],
+        },
+        { name: 'sales.orders', columns: [] },
+      ],
+    });
+  });
+
+  it('returns an empty terminal page when the offset is beyond the schema', () => {
+    expect(readBigQuerySchemaPage(resultWithRows([]), 99, 25)).toEqual({
+      page: 99,
+      pageSize: 25,
+      hasMore: false,
+      nextPage: null,
+      schema: [],
+    });
+  });
+
+  it('rejects malformed metadata rows instead of silently dropping tables', () => {
+    expect(() => readBigQuerySchemaPage(resultWithRows([
+      null as unknown as Record<string, unknown>,
+    ]), 1, 25)).toThrow(
+      'BigQuery metadata query response contained an invalid result row',
+    );
+    expect(() => readBigQuerySchemaPage(resultWithRows([{ has_more: false }]), 1, 25)).toThrow(
+      'BigQuery metadata query returned a row without a table name',
+    );
+    expect(() => readBigQuerySchemaPage(resultWithRows([{
+      table_name: 'analytics.events',
+      columns_json: 'not json',
+      has_more: false,
+    }]), 1, 25)).toThrow(
+      'BigQuery metadata query returned invalid columns for table analytics.events',
+    );
+  });
+});

--- a/src/__tests__/mcpServer.test.ts
+++ b/src/__tests__/mcpServer.test.ts
@@ -69,6 +69,21 @@ describe("Redash MCP server", () => {
           q: { description: "Search query" },
         },
       });
+
+      const getSchema = result.tools.find((tool) => tool.name === "get_schema");
+      expect(getSchema?.inputSchema).toMatchObject({
+        properties: {
+          pageSize: {
+            default: 25,
+            maximum: 100,
+            description: "Number of tables per page (max 100)",
+          },
+        },
+      });
+      expect(getSchema?.inputSchema).not.toHaveProperty("properties.location");
+      expect(getSchema?.description).toContain(
+        "Query Results data sources are unsupported because their tables are created dynamically",
+      );
     } finally {
       await connection.close();
     }
@@ -89,6 +104,85 @@ describe("Redash MCP server", () => {
 
       expect(result.isError).not.toBe(true);
       expect(getQuerySpy).toHaveBeenCalledWith(42);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it("passes pagination and search arguments through get_schema", async () => {
+    const schemaPage = {
+      page: 2,
+      pageSize: 10,
+      hasMore: false,
+      nextPage: null,
+      schema: [{ name: "users", columns: [{ name: "id", type: "integer" }] }],
+    };
+    const getSchemaPageSpy = jest
+      .spyOn(redashClient, "getSchemaPage")
+      .mockResolvedValue(schemaPage as never);
+    const connection = await connectDirectClient();
+
+    try {
+      const result = await connection.client.callTool({
+        name: "get_schema",
+        arguments: { dataSourceId: "3", page: "2", pageSize: "10", search: "user" },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(getSchemaPageSpy).toHaveBeenCalledWith(3, 2, 10, "user");
+      const [content] = result.content as Array<{ type: string; text: string }>;
+      expect(JSON.parse(content.text)).toEqual(schemaPage);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it("returns a pending Redash schema job unchanged", async () => {
+    const schemaJob = {
+      job: {
+        id: "schema-job-123",
+        updated_at: 0,
+        status: 1,
+        error: "",
+        result: null,
+        query_result_id: null,
+      },
+    };
+    jest.spyOn(redashClient, "getSchemaPage").mockResolvedValue(schemaJob);
+    const connection = await connectDirectClient();
+
+    try {
+      const result = await connection.client.callTool({
+        name: "get_schema",
+        arguments: { dataSourceId: 3 },
+      });
+
+      expect(result.isError).not.toBe(true);
+      const [content] = result.content as Array<{ type: string; text: string }>;
+      expect(JSON.parse(content.text)).toEqual(schemaJob);
+    } finally {
+      await connection.close();
+    }
+  });
+
+  it("returns actionable guidance when a data source has no static schema", async () => {
+    jest.spyOn(redashClient, "getSchemaPage").mockRejectedValue(new Error(
+      "Data source 13 is a Query Results data source and does not expose a static schema; "
+      + "use execute_adhoc_query with query_<query_id> or cached_query_<query_id> instead",
+    ));
+    const connection = await connectDirectClient();
+
+    try {
+      const result = await connection.client.callTool({
+        name: "get_schema",
+        arguments: { dataSourceId: 13 },
+      });
+
+      expect(result.isError).toBe(true);
+      const [content] = result.content as Array<{ type: string; text: string }>;
+      expect(content.text).toContain("Query Results data source");
+      expect(content.text).toContain("execute_adhoc_query");
+      expect(content.text).toContain("query_<query_id>");
     } finally {
       await connection.close();
     }

--- a/src/__tests__/redashClient.test.ts
+++ b/src/__tests__/redashClient.test.ts
@@ -1,8 +1,10 @@
 import { RedashClient } from '../redashClient.js';
 import axios from 'axios';
 import { jest } from '@jest/globals';
+import { Readable } from 'node:stream';
 import { logger } from '../logger.js';
 import { isToolContentCaptureEnabled } from '../telemetry.js';
+import type { RedashSchemaPage, RedashSchemaResponse } from '../schemaStream.js';
 
 // Mock axios
 jest.mock('axios');
@@ -23,6 +25,12 @@ jest.mock('../telemetry.js', () => ({
 }));
 
 const mockedContentCapture = jest.mocked(isToolContentCaptureEnabled);
+
+function expectSchemaPage(response: RedashSchemaResponse): asserts response is RedashSchemaPage {
+  if (!('schema' in response)) {
+    throw new Error('Expected a schema page, received a schema job');
+  }
+}
 
 describe('RedashClient', () => {
   let client: RedashClient;
@@ -79,6 +87,28 @@ describe('RedashClient', () => {
         },
         timeout: 30000,
       });
+    });
+
+    it('should fall back to the default timeout for invalid REDASH_TIMEOUT values', () => {
+      for (const value of ['abc', ' ', '0', '30s']) {
+        process.env.REDASH_TIMEOUT = value;
+        mockedAxios.create.mockClear();
+        new RedashClient();
+
+        expect(mockedAxios.create).toHaveBeenCalledWith(
+          expect.objectContaining({ timeout: 30000 })
+        );
+      }
+    });
+
+    it('should use a valid custom REDASH_TIMEOUT value', () => {
+      process.env.REDASH_TIMEOUT = '5000';
+      mockedAxios.create.mockClear();
+      new RedashClient();
+
+      expect(mockedAxios.create).toHaveBeenCalledWith(
+        expect.objectContaining({ timeout: 5000 })
+      );
     });
 
     it('should parse JSON extra headers', () => {
@@ -767,6 +797,380 @@ describe('RedashClient', () => {
 
       expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources/1/schema');
       expect(result).toEqual(mockSchema);
+    });
+  });
+
+  describe('getSchemaPage', () => {
+    beforeEach(() => {
+      // Most tests in this block exercise the streamed non-BigQuery path.
+      // Seed the type cache so each one can keep its HTTP mock focused on the
+      // schema request under test.
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.set(1, 'pg');
+    });
+
+    const mockSchema = {
+      schema: [
+        {
+          name: 'users',
+          columns: [
+            { name: 'id', type: 'integer' },
+            { name: 'email', type: 'string' },
+          ],
+        },
+        {
+          name: 'orders',
+          columns: [{ name: 'id', type: 'integer' }],
+        },
+      ],
+    };
+
+    function schemaStream() {
+      return Readable.from([Buffer.from(JSON.stringify(mockSchema))]);
+    }
+
+    it('should stream a schema page', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: schemaStream() });
+
+      const result = await client.getSchemaPage(1, 1, 25);
+
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources/1/schema', {
+        responseType: 'stream',
+      });
+      expect(result).toEqual({
+        page: 1,
+        pageSize: 25,
+        hasMore: false,
+        nextPage: null,
+        schema: mockSchema.schema,
+      });
+    });
+
+    it('should default to page 1 with pageSize 25', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: schemaStream() });
+
+      const result = await client.getSchemaPage(1);
+      expectSchemaPage(result);
+
+      expect(result.page).toBe(1);
+      expect(result.pageSize).toBe(25);
+    });
+
+    it('should return a pending schema job unchanged', async () => {
+      const response = {
+        job: {
+          id: 'schema-job-123',
+          updated_at: 0,
+          status: 1,
+          error: '',
+          result: null,
+          query_result_id: null,
+        },
+      };
+      mockAxiosInstance.get.mockResolvedValue({
+        data: Readable.from([Buffer.from(JSON.stringify(response))]),
+      });
+
+      await expect(client.getSchemaPage(1)).resolves.toEqual(response);
+    });
+
+    it('should stream the schema when listing data sources is forbidden', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.clear();
+      const forbidden = Object.assign(new Error('Request failed with status code 403'), {
+        response: { status: 403 },
+      });
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(forbidden)
+        .mockResolvedValueOnce({ data: schemaStream() });
+
+      const result = await client.getSchemaPage(1, 1, 25);
+      expectSchemaPage(result);
+
+      expect(result.schema).toEqual(mockSchema.schema);
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(1, '/api/data_sources');
+      expect(mockAxiosInstance.get).toHaveBeenNthCalledWith(2, '/api/data_sources/1/schema', {
+        responseType: 'stream',
+      });
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledWith(
+        'Could not determine the data-source type; falling back to the Redash schema endpoint',
+        expect.objectContaining({
+          'redash.data_source.id': 1,
+          'redash.schema.page': 1,
+          'redash.schema.page_size': 25,
+        }),
+        expect.any(Error),
+      );
+    });
+
+    it('should explain that Query Results has no static schema without calling its schema endpoint', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.clear();
+      mockAxiosInstance.get.mockResolvedValue({
+        data: [{ id: 13, name: 'Query Results', type: 'results' }],
+      });
+
+      await expect(client.getSchemaPage(13)).rejects.toThrow(
+        'Data source 13 is a Query Results data source and does not expose a static schema; '
+        + 'use execute_adhoc_query with query_<query_id> or cached_query_<query_id> instead'
+      );
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(1);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources');
+      expect(mockAxiosInstance.get).not.toHaveBeenCalledWith(
+        '/api/data_sources/13/schema',
+        expect.anything(),
+      );
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('should reject an invalid page without calling Redash', async () => {
+      await expect(client.getSchemaPage(1, 0)).rejects.toThrow('page must be a positive integer');
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    it('should reject an invalid pageSize without calling Redash', async () => {
+      await expect(client.getSchemaPage(1, 1, 101)).rejects.toThrow(
+        'pageSize must be an integer between 1 and 100'
+      );
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    it('should reject a page whose offset cannot be represented safely', async () => {
+      await expect(client.getSchemaPage(1, Number.MAX_SAFE_INTEGER, 100)).rejects.toThrow(
+        'page and pageSize produce an unsupported offset'
+      );
+      expect(mockAxiosInstance.get).not.toHaveBeenCalled();
+    });
+
+    it('should query INFORMATION_SCHEMA for BigQuery and cache discovery metadata', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.clear();
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({
+          data: [{ id: 4, name: 'bigquery', type: 'bigquery' }],
+        })
+        .mockResolvedValueOnce({
+          data: { id: 4, type: 'bigquery', options: { location: 'ASIA-NORTHEAST1' } },
+        });
+      mockAxiosInstance.post
+        .mockResolvedValueOnce({
+          data: {
+            query_result: {
+              data: {
+                rows: [{
+                  page_position: 1,
+                  table_name: 'analytics.events',
+                  table_description: null,
+                  columns_json: JSON.stringify([{ name: 'event_date', type: 'STRING' }]),
+                  has_more: true,
+                }],
+              },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          data: {
+            query_result: {
+              data: {
+                rows: [{
+                  page_position: 1,
+                  table_name: 'sales.orders',
+                  table_description: null,
+                  columns_json: JSON.stringify([{ name: 'id', type: 'INT64' }]),
+                  has_more: false,
+                }],
+              },
+            },
+          },
+        });
+
+      const page1 = await client.getSchemaPage(4, 1, 1, 'analytics');
+      const page2 = await client.getSchemaPage(4, 2, 1, 'analytics');
+      expectSchemaPage(page1);
+      expectSchemaPage(page2);
+
+      expect(page1.schema[0]?.name).toBe('analytics.events');
+      expect(page1.hasMore).toBe(true);
+      expect(page2.schema[0]?.name).toBe('sales.orders');
+      expect(page2.hasMore).toBe(false);
+      expect(mockAxiosInstance.get).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources');
+      expect(mockAxiosInstance.get).toHaveBeenCalledWith('/api/data_sources/4');
+      expect(mockAxiosInstance.get).not.toHaveBeenCalledWith(
+        '/api/data_sources/4/schema',
+        expect.anything(),
+      );
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(2);
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(
+        1,
+        '/api/query_results',
+        expect.objectContaining({
+          query: expect.stringContaining('LIMIT 2 OFFSET 0'),
+          data_source_id: 4,
+          apply_auto_limit: false,
+        }),
+      );
+      expect(mockAxiosInstance.post).toHaveBeenNthCalledWith(
+        2,
+        '/api/query_results',
+        expect.objectContaining({
+          query: expect.stringContaining('LIMIT 2 OFFSET 1'),
+          data_source_id: 4,
+          apply_auto_limit: false,
+        }),
+      );
+    });
+
+    it('should cache every data-source type returned by the first discovery request', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.clear();
+      mockAxiosInstance.get.mockImplementation((path: string) => {
+        if (path === '/api/data_sources') {
+          return Promise.resolve({
+            data: [
+              { id: 1, name: 'postgres', type: 'pg' },
+              { id: 2, name: 'mysql', type: 'mysql' },
+              { id: 'invalid', name: 'invalid', type: 'pg' },
+              { id: 3, name: 'missing-type' },
+            ],
+          });
+        }
+        if (path === '/api/data_sources/1/schema' || path === '/api/data_sources/2/schema') {
+          return Promise.resolve({ data: schemaStream() });
+        }
+        return Promise.reject(new Error(`Unexpected path: ${path}`));
+      });
+
+      await client.getSchemaPage(1);
+      await client.getSchemaPage(2);
+
+      const discoveryCalls = mockAxiosInstance.get.mock.calls
+        .filter(([path]: [string]) => path === '/api/data_sources');
+      expect(discoveryCalls).toHaveLength(1);
+    });
+
+    it('should stream the schema when the BigQuery location is unavailable and cache that choice', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.set(4, 'bigquery');
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({ data: { id: 4, type: 'bigquery', options: {} } })
+        .mockResolvedValueOnce({ data: schemaStream() })
+        .mockResolvedValueOnce({ data: schemaStream() });
+
+      const first = await client.getSchemaPage(4, 1, 1);
+      const second = await client.getSchemaPage(4, 2, 1);
+      expectSchemaPage(first);
+      expectSchemaPage(second);
+
+      expect(first.schema).toEqual([mockSchema.schema[0]]);
+      expect(second.schema).toEqual([mockSchema.schema[1]]);
+      expect(mockAxiosInstance.get.mock.calls
+        .filter(([path]: [string]) => path === '/api/data_sources/4')).toHaveLength(1);
+      expect(mockAxiosInstance.get.mock.calls
+        .filter(([path]: [string]) => path === '/api/data_sources/4/schema')).toHaveLength(2);
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+    });
+
+    it('should stream the schema when BigQuery data-source discovery fails', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.set(4, 'bigquery');
+      mockAxiosInstance.get
+        .mockRejectedValueOnce(new Error('detail unavailable'))
+        .mockResolvedValueOnce({ data: schemaStream() });
+
+      const result = await client.getSchemaPage(4, 1, 25);
+      expectSchemaPage(result);
+
+      expect(result.schema).toEqual(mockSchema.schema);
+      expect(mockAxiosInstance.post).not.toHaveBeenCalled();
+      expect(logger.warning).toHaveBeenCalledWith(
+        'Could not read the configured BigQuery location; falling back to the Redash schema endpoint',
+        expect.objectContaining({
+          'redash.data_source.id': 4,
+          'redash.schema.page': 1,
+          'redash.schema.page_size': 25,
+        }),
+        expect.any(Error),
+      );
+    });
+
+    it('should fall back and disable the optimization after a BigQuery metadata query fails', async () => {
+      (client as unknown as { dataSourceTypes: Map<number, string> })
+        .dataSourceTypes.set(4, 'bigquery');
+      mockAxiosInstance.get
+        .mockResolvedValueOnce({
+          data: { id: 4, type: 'bigquery', options: { location: 'us' } },
+        })
+        .mockResolvedValueOnce({ data: schemaStream() })
+        .mockResolvedValueOnce({ data: schemaStream() });
+      mockAxiosInstance.post.mockRejectedValue(new Error('warehouse unavailable'));
+
+      const first = await client.getSchemaPage(4, 1, 1, 'user');
+      const second = await client.getSchemaPage(4, 1, 1, 'order');
+      expectSchemaPage(first);
+      expectSchemaPage(second);
+
+      expect(first.schema).toEqual([mockSchema.schema[0]]);
+      expect(second.schema).toEqual([mockSchema.schema[1]]);
+      expect(mockAxiosInstance.post).toHaveBeenCalledTimes(1);
+      expect(logger.warning).toHaveBeenCalledWith(
+        'BigQuery schema pagination failed; falling back to the Redash schema endpoint',
+        expect.objectContaining({
+          'redash.data_source.id': 4,
+          'redash.schema.search_present': true,
+        }),
+        expect.any(Error),
+      );
+    });
+
+    it('should log only a search marker unless content capture is enabled', async () => {
+      mockAxiosInstance.get.mockResolvedValue({ data: schemaStream() });
+
+      await client.getSchemaPage(1, 1, 25, 'users');
+
+      const [, fields] = (logger.debug as jest.Mock).mock.calls[0] as [string, Record<string, unknown>];
+      expect(fields['redash.schema.search_present']).toBe(true);
+      expect(fields['redash.schema.search']).toBeUndefined();
+    });
+
+    it('should log the search term when content capture is enabled', async () => {
+      mockedContentCapture.mockReturnValue(true);
+      mockAxiosInstance.get.mockResolvedValue({ data: schemaStream() });
+
+      await client.getSchemaPage(1, 1, 25, 'users');
+
+      const [, fields] = (logger.debug as jest.Mock).mock.calls[0] as [string, Record<string, unknown>];
+      expect(fields['redash.schema.search']).toBe('users');
+      expect(fields['redash.schema.search_present']).toBe(true);
+    });
+
+    it('should destroy stream error bodies and keep them out of log fields', async () => {
+      mockedContentCapture.mockReturnValue(true);
+      (mockedAxios.isAxiosError as unknown as jest.Mock).mockReturnValue(true);
+      const errorBody = new Readable({ read() {} });
+      mockAxiosInstance.get.mockRejectedValue({
+        isAxiosError: true,
+        message: 'Request failed with status code 500',
+        response: { status: 500, data: errorBody },
+      });
+
+      await expect(client.getSchemaPage(1)).rejects.toThrow(
+        'Failed to fetch schema page for data source 1: Redash API error (500)'
+      );
+      expect(errorBody.destroyed).toBe(true);
+      const [, fields] = (logger.error as jest.Mock).mock.calls[0] as [string, Record<string, unknown>];
+      expect(fields['redash.response.body']).toBeUndefined();
+      expect(fields['http.response.status_code']).toBe(500);
+    });
+
+    it('should wrap non-axios errors', async () => {
+      mockAxiosInstance.get.mockRejectedValue(new Error('socket hang up'));
+
+      await expect(client.getSchemaPage(1)).rejects.toThrow(
+        'Failed to fetch schema page for data source 1: socket hang up'
+      );
     });
   });
 

--- a/src/__tests__/schemaStream.test.ts
+++ b/src/__tests__/schemaStream.test.ts
@@ -1,0 +1,233 @@
+import { Readable } from 'node:stream';
+import {
+  readSchemaPage,
+  type RedashSchemaPage,
+  type RedashSchemaResponse,
+  type SchemaTable,
+} from '../schemaStream.js';
+
+function expectSchemaPage(response: RedashSchemaResponse): asserts response is RedashSchemaPage {
+  if (!('schema' in response)) {
+    throw new Error('Expected a schema page, received a schema job');
+  }
+}
+
+function makeTables(count: number, namePrefix = 'table_'): SchemaTable[] {
+  return Array.from({ length: count }, (_, i) => ({
+    name: `${namePrefix}${String(i).padStart(4, '0')}`,
+    columns: [
+      { name: 'id', type: 'integer' },
+      { name: 'value', type: 'string' },
+    ],
+  }));
+}
+
+function* bufferChunks(buffer: Buffer, size: number): Generator<Buffer> {
+  for (let i = 0; i < buffer.length; i += size) {
+    yield buffer.subarray(i, i + size);
+  }
+}
+
+// Deliberately small chunks so parsing is proven to work across chunk
+// boundaries, including boundaries inside multi-byte UTF-8 sequences.
+function sourceFrom(json: string, chunkSize = 7): Readable {
+  return Readable.from(bufferChunks(Buffer.from(json), chunkSize));
+}
+
+function schemaJson(tables: SchemaTable[]): string {
+  return JSON.stringify({ schema: tables });
+}
+
+const baseOptions = { page: 1, pageSize: 25, deadlineMs: 5000 };
+
+describe('readSchemaPage', () => {
+  it('returns everything when the schema fits in one page', async () => {
+    const tables = makeTables(3);
+    const result = await readSchemaPage(sourceFrom(schemaJson(tables)), baseOptions);
+
+    expect(result).toEqual({
+      page: 1,
+      pageSize: 25,
+      hasMore: false,
+      nextPage: null,
+      schema: tables,
+    });
+  });
+
+  it('parses table names with multi-byte characters split across chunks', async () => {
+    const tables: SchemaTable[] = [
+      { name: '売上データ.注文履歴', columns: [{ name: '注文番号', type: 'string' }] },
+    ];
+    const result = await readSchemaPage(sourceFrom(schemaJson(tables), 3), baseOptions);
+    expectSchemaPage(result);
+
+    expect(result.schema).toEqual(tables);
+  });
+
+  it('reports hasMore/nextPage at the page boundary', async () => {
+    const tables = makeTables(26);
+    const json = schemaJson(tables);
+
+    const page1 = await readSchemaPage(sourceFrom(json), baseOptions);
+    expectSchemaPage(page1);
+    expect(page1.schema).toEqual(tables.slice(0, 25));
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextPage).toBe(2);
+
+    const page2 = await readSchemaPage(sourceFrom(json), { ...baseOptions, page: 2 });
+    expectSchemaPage(page2);
+    expect(page2.schema).toEqual(tables.slice(25));
+    expect(page2.hasMore).toBe(false);
+    expect(page2.nextPage).toBeNull();
+  });
+
+  it('does not report hasMore when the last page is exactly full', async () => {
+    const tables = makeTables(50);
+    const result = await readSchemaPage(sourceFrom(schemaJson(tables)), { ...baseOptions, page: 2 });
+    expectSchemaPage(result);
+
+    expect(result.schema).toEqual(tables.slice(25));
+    expect(result.hasMore).toBe(false);
+    expect(result.nextPage).toBeNull();
+  });
+
+  it('returns an empty page beyond the end of the schema', async () => {
+    const result = await readSchemaPage(sourceFrom(schemaJson(makeTables(10))), { ...baseOptions, page: 3 });
+    expectSchemaPage(result);
+
+    expect(result.schema).toEqual([]);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextPage).toBeNull();
+  });
+
+  it('filters by search case-insensitively and paginates the filtered set', async () => {
+    const tables = [...makeTables(170, 'events_'), ...makeTables(30, 'Users_')];
+    const json = schemaJson(tables);
+
+    const page1 = await readSchemaPage(sourceFrom(json, 64), { ...baseOptions, search: 'users' });
+    expectSchemaPage(page1);
+    expect(page1.schema).toEqual(tables.slice(170, 195));
+    expect(page1.hasMore).toBe(true);
+    expect(page1.nextPage).toBe(2);
+
+    const page2 = await readSchemaPage(sourceFrom(json, 64), { ...baseOptions, page: 2, search: 'users' });
+    expectSchemaPage(page2);
+    expect(page2.schema).toEqual(tables.slice(195));
+    expect(page2.hasMore).toBe(false);
+  });
+
+  it('destroys the source early once the page is complete', async () => {
+    const buffer = Buffer.from(schemaJson(makeTables(2000)));
+    const chunkSize = 512;
+    const totalChunks = Math.ceil(buffer.length / chunkSize);
+    let yielded = 0;
+    async function* countingChunks() {
+      for (const chunk of bufferChunks(buffer, chunkSize)) {
+        yielded += 1;
+        yield chunk;
+      }
+    }
+    const source = Readable.from(countingChunks());
+
+    const result = await readSchemaPage(source, baseOptions);
+    expectSchemaPage(result);
+
+    expect(result.schema).toHaveLength(25);
+    expect(result.hasMore).toBe(true);
+    expect(source.destroyed).toBe(true);
+    expect(yielded).toBeLessThan(totalChunks / 2);
+  });
+
+  it('rejects on malformed JSON', async () => {
+    await expect(readSchemaPage(sourceFrom('{"schema": [{'), baseOptions)).rejects.toThrow();
+  });
+
+  it('rejects when the response lacks a schema array', async () => {
+    await expect(
+      readSchemaPage(sourceFrom('{"message": "Internal Server Error"}'), baseOptions),
+    ).rejects.toThrow('Redash schema response did not contain a "schema" array');
+  });
+
+  it('resolves an empty schema as an empty page', async () => {
+    const result = await readSchemaPage(sourceFrom('{"schema": []}'), baseOptions);
+
+    expect(result).toEqual({
+      page: 1,
+      pageSize: 25,
+      hasMore: false,
+      nextPage: null,
+      schema: [],
+    });
+  });
+
+  it('returns a pending Redash schema job without treating it as malformed', async () => {
+    const response = {
+      job: {
+        id: 'schema-job-123',
+        updated_at: 0,
+        status: 1,
+        error: '',
+        result: null,
+        query_result_id: null,
+      },
+    };
+
+    const result = await readSchemaPage(sourceFrom(JSON.stringify(response), 3), baseOptions);
+
+    expect(result).toEqual(response);
+  });
+
+  it('paginates a schema job that completed before its initial response was serialized', async () => {
+    const tables = makeTables(3);
+    const response = {
+      job: {
+        id: 'schema-job-123',
+        updated_at: 1,
+        status: 3,
+        error: '',
+        result: tables,
+        // Redash duplicates job.result into this legacy field.
+        query_result_id: tables,
+      },
+    };
+
+    const result = await readSchemaPage(sourceFrom(JSON.stringify(response), 5), {
+      ...baseOptions,
+      page: 2,
+      pageSize: 2,
+    });
+
+    expect(result).toEqual({
+      page: 2,
+      pageSize: 2,
+      hasMore: false,
+      nextPage: null,
+      schema: tables.slice(2),
+    });
+  });
+
+  it('rejects when schema is not an array', async () => {
+    await expect(
+      readSchemaPage(sourceFrom('{"schema": {"not": "an array"}}'), baseOptions),
+    ).rejects.toThrow();
+  });
+
+  it('rejects invalid pagination and destroys the source before parsing', async () => {
+    const source = sourceFrom('{"schema": []}');
+
+    await expect(
+      readSchemaPage(source, { ...baseOptions, pageSize: 101 }),
+    ).rejects.toThrow('pageSize must be an integer between 1 and 100');
+    expect(source.destroyed).toBe(true);
+  });
+
+  it('rejects when the source stalls past the deadline', async () => {
+    const source = new Readable({ read() {} });
+    source.push('{"schema": [');
+
+    await expect(
+      readSchemaPage(source, { ...baseOptions, deadlineMs: 50 }),
+    ).rejects.toThrow(/Timed out reading schema response after 50ms/);
+    expect(source.destroyed).toBe(true);
+  });
+});

--- a/src/bigQuerySchema.ts
+++ b/src/bigQuerySchema.ts
@@ -1,0 +1,191 @@
+import type { RedashSchemaPage, SchemaTable } from './schemaStream.js';
+import { schemaPageOffset } from './schemaPagination.js';
+
+type QueryRows = Array<Record<string, unknown>>;
+
+function queryRows(response: unknown): QueryRows {
+  if (typeof response !== 'object' || response === null) {
+    throw new Error('BigQuery metadata query returned an invalid response');
+  }
+
+  const outer = response as Record<string, unknown>;
+  const queryResult = typeof outer.query_result === 'object' && outer.query_result !== null
+    ? outer.query_result as Record<string, unknown>
+    : outer;
+  const data = queryResult.data;
+  if (typeof data !== 'object' || data === null) {
+    throw new Error('BigQuery metadata query response did not contain result data');
+  }
+
+  const rows = (data as Record<string, unknown>).rows;
+  if (!Array.isArray(rows)) {
+    throw new Error('BigQuery metadata query response did not contain result rows');
+  }
+  if (!rows.every(row => typeof row === 'object' && row !== null)) {
+    throw new Error('BigQuery metadata query response contained an invalid result row');
+  }
+
+  return rows as QueryRows;
+}
+
+export function readBigQueryDataSourceLocation(dataSource: unknown): string | null {
+  if (typeof dataSource !== 'object' || dataSource === null) {
+    return null;
+  }
+
+  const options = (dataSource as Record<string, unknown>).options;
+  if (typeof options !== 'object' || options === null) {
+    return null;
+  }
+
+  const location = (options as Record<string, unknown>).location;
+  if (typeof location !== 'string' || !/^[a-z0-9-]+$/i.test(location)) {
+    return null;
+  }
+
+  return location.toLowerCase();
+}
+
+export function buildBigQuerySchemaPageQuery(
+  location: string,
+  page: number,
+  pageSize: number,
+  search?: string,
+): string {
+  if (!/^[a-z0-9-]+$/i.test(location)) {
+    throw new Error('BigQuery location contained unexpected characters');
+  }
+
+  const offset = schemaPageOffset(page, pageSize);
+
+  const region = `region-${location.toLowerCase()}`;
+  const searchPredicate = search === undefined
+    ? ''
+    : `\n    AND STRPOS(\n      LOWER(CONCAT(table_schema, '.', table_name)),\n      LOWER(CAST(FROM_HEX('${Buffer.from(search, 'utf8').toString('hex')}') AS STRING))\n    ) > 0`;
+
+  return `
+WITH candidate_tables AS (
+  SELECT table_catalog, table_schema, table_name
+  FROM \`${region}\`.INFORMATION_SCHEMA.TABLES
+  WHERE table_schema != 'INFORMATION_SCHEMA'${searchPredicate}
+  ORDER BY table_schema, table_name
+  LIMIT ${pageSize + 1} OFFSET ${offset}
+),
+numbered_tables AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (ORDER BY table_schema, table_name) AS page_position
+  FROM candidate_tables
+),
+page_tables AS (
+  SELECT *
+  FROM numbered_tables
+  WHERE page_position <= ${pageSize}
+),
+table_descriptions AS (
+  SELECT
+    d.table_catalog,
+    d.table_schema,
+    d.table_name,
+    ANY_VALUE(JSON_VALUE(d.option_value)) AS table_description
+  FROM \`${region}\`.INFORMATION_SCHEMA.TABLE_OPTIONS AS d
+  JOIN page_tables AS t
+    USING (table_catalog, table_schema, table_name)
+  WHERE d.option_name = 'description'
+  GROUP BY d.table_catalog, d.table_schema, d.table_name
+)
+SELECT
+  t.page_position,
+  CONCAT(t.table_schema, '.', t.table_name) AS table_name,
+  d.table_description,
+  IFNULL(
+    TO_JSON_STRING(ARRAY_AGG(
+      IF(c.field_path IS NULL, NULL, STRUCT(
+        c.field_path AS name,
+        c.data_type AS type,
+        c.description AS description
+      ))
+      IGNORE NULLS
+      ORDER BY c.field_path
+    )),
+    '[]'
+  ) AS columns_json,
+  (SELECT COUNT(*) > ${pageSize} FROM numbered_tables) AS has_more
+FROM page_tables AS t
+LEFT JOIN \`${region}\`.INFORMATION_SCHEMA.COLUMN_FIELD_PATHS AS c
+  USING (table_catalog, table_schema, table_name)
+LEFT JOIN table_descriptions AS d
+  USING (table_catalog, table_schema, table_name)
+GROUP BY t.page_position, t.table_schema, t.table_name, d.table_description
+ORDER BY t.page_position
+  `.trim();
+}
+
+export function readBigQuerySchemaPage(
+  response: unknown,
+  page: number,
+  pageSize: number,
+): RedashSchemaPage {
+  const rows = queryRows(response);
+  const tables: SchemaTable[] = [];
+  const byName = new Map<string, SchemaTable>();
+
+  for (const row of rows) {
+    const tableName = row.table_name;
+    if (typeof tableName !== 'string') {
+      throw new Error('BigQuery metadata query returned a row without a table name');
+    }
+
+    let table = byName.get(tableName);
+    if (table === undefined) {
+      table = { name: tableName, columns: [] };
+      if (typeof row.table_description === 'string') {
+        table.description = row.table_description;
+      }
+      byName.set(tableName, table);
+      tables.push(table);
+    }
+
+    if (typeof row.columns_json !== 'string') {
+      throw new Error(`BigQuery metadata query returned invalid columns for table ${tableName}`);
+    }
+
+    let columns: unknown;
+    try {
+      columns = JSON.parse(row.columns_json);
+    } catch {
+      throw new Error(`BigQuery metadata query returned invalid columns for table ${tableName}`);
+    }
+    if (!Array.isArray(columns)) {
+      throw new Error(`BigQuery metadata query returned invalid columns for table ${tableName}`);
+    }
+
+    for (const column of columns) {
+      if (
+        typeof column !== 'object'
+        || column === null
+        || typeof (column as Record<string, unknown>).name !== 'string'
+        || typeof (column as Record<string, unknown>).type !== 'string'
+      ) {
+        throw new Error(`BigQuery metadata query returned invalid columns for table ${tableName}`);
+      }
+      const record = column as Record<string, unknown>;
+      table.columns.push({
+        name: record.name as string,
+        type: record.type as string,
+        ...(typeof record.description === 'string'
+          ? { description: record.description }
+          : {}),
+      });
+    }
+  }
+
+  const hasMore = rows.some(row => row.has_more === true);
+  return {
+    page,
+    pageSize,
+    hasMore,
+    nextPage: hasMore ? page + 1 : null,
+    schema: tables,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { getRedashClient, CreateQueryRequest, UpdateQueryRequest, CreateVisualiz
 import { buildChartVisualizationOptions, chartVisualizationUpdateSchema } from "./chartVisualization.js";
 import { mergeNamedEntries, queryParameterPatchSchema, resolveParameterOrder, toNamedEntries, toNamedRecord, widgetParameterMappingPatchSchema } from "./parameterManagement.js";
 import { buildParameterizedExecutionParameters, ParameterizedExecutionError } from "./parameterizedExecution.js";
+import { DEFAULT_SCHEMA_PAGE_SIZE, MAX_SCHEMA_PAGE_SIZE } from "./schemaPagination.js";
 import { mergeDeep } from "./utils.js";
 import { buildWidgetLayoutOptions, dashboardGridDefaults, summarizeWidgetLayout, widgetLayoutEntrySchema, widgetPositionSchema } from "./widgetLayout.js";
 import { logger } from "./logger.js";
@@ -70,7 +71,7 @@ function defineTool<T extends ZodRawShape>(
   };
 }
 
-const paginationPageField = z.coerce.number().optional().default(1).describe("Page number (starts at 1)");
+const paginationPageField = z.coerce.number().int().min(1).optional().default(1).describe("Page number (starts at 1)");
 const paginationPageSizeField = z.coerce.number().optional().default(25).describe("Number of results per page");
 
 // ----- Tools Implementation -----
@@ -865,18 +866,23 @@ async function deleteVisualization(params: z.infer<typeof deleteVisualizationSch
 // Tool: get_schema
 const getSchemaSchema = z.object({
   dataSourceId: z.coerce.number().describe("ID of the data source to get schema"),
+  page: paginationPageField,
+  pageSize: z.coerce.number().int().min(1).max(MAX_SCHEMA_PAGE_SIZE).optional().default(DEFAULT_SCHEMA_PAGE_SIZE)
+    .describe(`Number of tables per page (max ${MAX_SCHEMA_PAGE_SIZE})`),
+  search: z.string().optional()
+    .describe("Case-insensitive substring filter on table names; pagination applies to the filtered set"),
 });
 
 async function getSchema(params: z.infer<typeof getSchemaSchema>) {
   try {
-    const { dataSourceId } = params;
-    const query = await getRedashClient().getSchema(dataSourceId);
+    const { dataSourceId, page, pageSize, search } = params;
+    const schemaPage = await getRedashClient().getSchemaPage(dataSourceId, page, pageSize, search);
 
     return {
       content: [
         {
           type: "text",
-          text: JSON.stringify(query, null, 2),
+          text: JSON.stringify(schemaPage, null, 2),
         },
       ],
     };
@@ -2190,7 +2196,7 @@ export const toolDefinitions = [
     chartVisualizationUpdateSchema,
   ),
   defineTool("delete_visualization", "Delete a visualization", deleteVisualization, deleteVisualizationSchema),
-  defineTool("get_schema", "Get schema of a specific data source", getSchema, getSchemaSchema),
+  defineTool("get_schema", "Get a schema page without buffering the complete schema in MCP; BigQuery is paged at the source when its configured location is available. Returns hasMore/nextPage and supports table-name search. Query Results data sources are unsupported because their tables are created dynamically", getSchema, getSchemaSchema),
   defineTool("create_dashboard", "Create a new dashboard in Redash", createDashboard, createDashboardSchema),
   defineTool("update_dashboard", "Update an existing dashboard in Redash", updateDashboard, updateDashboardSchema),
   defineTool("get_dashboard_parameters", "Get the current dashboard parameter values and widget mappings", getDashboardParameters, getDashboardParametersSchema),

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -1,9 +1,21 @@
 import axios, { AxiosInstance, AxiosError } from 'axios';
 import * as dotenv from 'dotenv';
+import { Readable } from 'node:stream';
 import { SocksProxyAgent } from 'socks-proxy-agent';
 import { logger, type LogFields } from './logger.js';
+import {
+  buildBigQuerySchemaPageQuery,
+  readBigQueryDataSourceLocation,
+  readBigQuerySchemaPage,
+} from './bigQuerySchema.js';
+import { DEFAULT_SCHEMA_PAGE_SIZE, schemaPageOffset } from './schemaPagination.js';
+import {
+  readSchemaPage,
+  type RedashSchemaPage,
+  type RedashSchemaResponse,
+} from './schemaStream.js';
 import { isToolContentCaptureEnabled } from './telemetry.js';
-import { formatError } from './utils.js';
+import { destroyQuietly, formatError } from './utils.js';
 
 dotenv.config({ quiet: true });
 
@@ -150,7 +162,9 @@ function redashRequestErrorFields(
     },
     {
       "redash.request.body": requestBody,
-      "redash.response.body": response?.data,
+      // Streamed error bodies (responseType: 'stream') carry sockets and
+      // buffered response fragments; they must never land in log attributes.
+      "redash.response.body": response?.data instanceof Readable ? undefined : response?.data,
     },
   );
 }
@@ -316,10 +330,20 @@ export class RedashClient {
   private client: AxiosInstance;
   private baseUrl: string;
   private apiKey: string;
+  private timeoutMs: number;
+  private dataSourceTypes = new Map<number, string>();
+  private bigQueryLocations = new Map<number, string | null>();
 
   constructor() {
     this.baseUrl = process.env.REDASH_URL || '';
     this.apiKey = process.env.REDASH_API_KEY || '';
+    // Strict digit check: parseInt would misread "30s" as 30 (a 30ms budget),
+    // and a NaN here would turn the schema-read deadline into ~1ms. The cap is
+    // the largest delay setTimeout supports.
+    const rawTimeout = (process.env.REDASH_TIMEOUT ?? '').trim();
+    this.timeoutMs = /^\d+$/.test(rawTimeout) && Number(rawTimeout) > 0
+      ? Math.min(Number(rawTimeout), 2147483647)
+      : 30000;
 
     if (!this.baseUrl || !this.apiKey) {
       throw new Error('REDASH_URL and REDASH_API_KEY must be provided in .env file');
@@ -344,7 +368,7 @@ export class RedashClient {
         ...defaultHeaders,
         ...extraHeaders,
       },
-      timeout: parseInt(process.env.REDASH_TIMEOUT || '30000')
+      timeout: this.timeoutMs
     };
 
     const socksProxy = process.env.REDASH_SOCKS_PROXY;
@@ -825,6 +849,171 @@ export class RedashClient {
         `Failed to fetch data source ${dataSourceId} schema from Redash`
       );
     }
+  }
+
+  // Get one page without materializing an entire warehouse schema in this MCP
+  // process. BigQuery can be paged at the source when Redash exposes its
+  // configured location; every other path parses the cached schema incrementally.
+  async getSchemaPage(
+    dataSourceId: number,
+    page = 1,
+    pageSize = DEFAULT_SCHEMA_PAGE_SIZE,
+    search?: string,
+  ): Promise<RedashSchemaResponse> {
+    schemaPageOffset(page, pageSize);
+
+    const prefix = `Failed to fetch schema page for data source ${dataSourceId}`;
+    const schemaFields: LogFields = {
+      "redash.data_source.id": dataSourceId,
+      "redash.schema.page": page,
+      "redash.schema.page_size": pageSize,
+      ...(search !== undefined ? { "redash.schema.search_present": true } : {}),
+    };
+    const loggedSchemaFields = withCapturedRedashContent(schemaFields, {
+      "redash.schema.search": search,
+    });
+
+    let dataSourceType: string | undefined;
+    try {
+      dataSourceType = await this.getDataSourceType(dataSourceId);
+    } catch (error) {
+      // Listing data sources requires the global list_data_sources permission,
+      // while the schema endpoint only requires access to this data source.
+      // Treat type discovery as an optional optimization so restricted API
+      // keys can still use the streamed schema endpoint.
+      logger.warning(
+        "Could not determine the data-source type; falling back to the Redash schema endpoint",
+        loggedSchemaFields,
+        error,
+      );
+    }
+
+    if (dataSourceType === 'results') {
+      throw new Error(
+        `Data source ${dataSourceId} is a Query Results data source and does not expose a static schema; `
+        + 'use execute_adhoc_query with query_<query_id> or cached_query_<query_id> instead'
+      );
+    }
+
+    if (dataSourceType === 'bigquery' || dataSourceType === 'bigquery_gce') {
+      let location: string | null = null;
+      try {
+        location = await this.getBigQueryLocation(dataSourceId);
+      } catch (error) {
+        logger.warning(
+          "Could not read the configured BigQuery location; falling back to the Redash schema endpoint",
+          loggedSchemaFields,
+          error,
+        );
+      }
+
+      if (location !== null) {
+        try {
+          return await this.getBigQuerySchemaPage(dataSourceId, location, page, pageSize, search);
+        } catch (error) {
+          this.bigQueryLocations.set(dataSourceId, null);
+          logger.warning(
+            "BigQuery schema pagination failed; falling back to the Redash schema endpoint",
+            loggedSchemaFields,
+            error,
+          );
+        }
+      }
+    }
+
+    const path = `/api/data_sources/${dataSourceId}/schema`;
+    const requestFields: LogFields = {
+      "http.request.method": "GET",
+      "url.path": path,
+      ...schemaFields,
+    };
+    // The search term is user-supplied tool input; like query text elsewhere in
+    // this file, it only reaches log attributes when content capture is on.
+    const loggedFields = withCapturedRedashContent(requestFields, {
+      "redash.schema.search": search,
+    });
+
+    try {
+      logger.debug(`Fetching schema page ${page} for data source ${dataSourceId}`, loggedFields);
+      const response = await this.client.get(path, {
+        responseType: 'stream'
+      });
+
+      return await readSchemaPage(response.data, {
+        page,
+        pageSize,
+        search,
+        deadlineMs: this.timeoutMs,
+      });
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        const axiosError = error as AxiosError;
+        const body: unknown = axiosError.response?.data;
+        if (body instanceof Readable) {
+          // Error bodies arrive as streams under responseType: 'stream';
+          // destroy them so the socket is released, and drop them so a
+          // Readable never rides along on the logged exception object.
+          destroyQuietly(body);
+          axiosError.response!.data = undefined;
+        }
+        logger.error(
+          "Redash schema request failed",
+          redashRequestErrorFields(loggedFields, axiosError),
+          axiosError,
+        );
+        throw redashRequestError(prefix, axiosError);
+      }
+      logger.error("Error fetching Redash schema page", loggedFields, error);
+      throw new Error(`${prefix}: ${formatError(error)}`);
+    }
+  }
+
+  private async getDataSourceType(dataSourceId: number): Promise<string> {
+    const cached = this.dataSourceTypes.get(dataSourceId);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const dataSources = await this.getDataSources();
+    for (const candidate of dataSources) {
+      if (typeof candidate?.id === 'number' && typeof candidate?.type === 'string') {
+        this.dataSourceTypes.set(candidate.id, candidate.type);
+      }
+    }
+    const dataSource = dataSources.find(candidate => candidate?.id === dataSourceId);
+    if (typeof dataSource?.type !== 'string') {
+      throw new Error(`Data source ${dataSourceId} was not found or did not report its type`);
+    }
+
+    return dataSource.type;
+  }
+
+  private async getBigQueryLocation(dataSourceId: number): Promise<string | null> {
+    if (this.bigQueryLocations.has(dataSourceId)) {
+      return this.bigQueryLocations.get(dataSourceId) ?? null;
+    }
+
+    try {
+      const response = await this.client.get(`/api/data_sources/${dataSourceId}`);
+      const location = readBigQueryDataSourceLocation(response.data);
+      this.bigQueryLocations.set(dataSourceId, location);
+      return location;
+    } catch (error) {
+      this.bigQueryLocations.set(dataSourceId, null);
+      throw error;
+    }
+  }
+
+  private async getBigQuerySchemaPage(
+    dataSourceId: number,
+    location: string,
+    page: number,
+    pageSize: number,
+    search?: string,
+  ): Promise<RedashSchemaPage> {
+    const query = buildBigQuerySchemaPageQuery(location, page, pageSize, search);
+    const result = await this.executeAdhocQuery(query, dataSourceId, false);
+    return readBigQuerySchemaPage(result, page, pageSize);
   }
 
   // ----- Dashboard API Methods -----

--- a/src/schemaPagination.ts
+++ b/src/schemaPagination.ts
@@ -1,0 +1,18 @@
+export const DEFAULT_SCHEMA_PAGE_SIZE = 25;
+export const MAX_SCHEMA_PAGE_SIZE = 100;
+
+export function schemaPageOffset(page: number, pageSize: number): number {
+  if (!Number.isSafeInteger(page) || page < 1) {
+    throw new Error('page must be a positive integer');
+  }
+  if (!Number.isInteger(pageSize) || pageSize < 1 || pageSize > MAX_SCHEMA_PAGE_SIZE) {
+    throw new Error(`pageSize must be an integer between 1 and ${MAX_SCHEMA_PAGE_SIZE}`);
+  }
+
+  const offset = (page - 1) * pageSize;
+  if (!Number.isSafeInteger(offset)) {
+    throw new Error('page and pageSize produce an unsupported offset');
+  }
+
+  return offset;
+}

--- a/src/schemaStream.ts
+++ b/src/schemaStream.ts
@@ -1,0 +1,196 @@
+import type { Readable } from 'node:stream';
+import chain from 'stream-chain';
+import Assembler from 'stream-json/assembler.js';
+import { parser } from 'stream-json';
+import type { Token } from 'stream-json/parser.js';
+import { pick } from 'stream-json/filters/pick.js';
+import { streamArray } from 'stream-json/streamers/stream-array.js';
+import { schemaPageOffset } from './schemaPagination.js';
+import { destroyQuietly } from './utils.js';
+
+export interface SchemaTable {
+  name: string;
+  description?: string | null;
+  columns: Array<{
+    name: string;
+    type: string;
+    description?: string | null;
+  }>;
+}
+
+export interface RedashSchemaPage {
+  page: number;
+  pageSize: number;
+  hasMore: boolean;
+  nextPage: number | null;
+  schema: SchemaTable[];
+}
+
+export interface RedashSchemaJobResponse {
+  job: Record<string, unknown>;
+}
+
+export type RedashSchemaResponse = RedashSchemaPage | RedashSchemaJobResponse;
+
+export interface ReadSchemaPageOptions {
+  page: number;
+  pageSize: number;
+  search?: string;
+  deadlineMs: number;
+}
+
+// Reads one page of tables from a Redash schema response body without ever
+// materializing the whole document: the body is parsed incrementally and the
+// stream is destroyed as soon as the requested page is complete, which also
+// aborts the underlying HTTP transfer.
+export async function readSchemaPage(
+  source: Readable,
+  options: ReadSchemaPageOptions,
+): Promise<RedashSchemaResponse> {
+  const { page, pageSize, search, deadlineMs } = options;
+  const searchLower = search?.toLowerCase();
+  let offset: number;
+  try {
+    offset = schemaPageOffset(page, pageSize);
+  } catch (error) {
+    destroyQuietly(source);
+    throw error;
+  }
+
+  // A cache miss makes Redash return {"job": {...}} while it refreshes the
+  // schema asynchronously. Preserve that small response just as the previous
+  // unpaginated client did. If the job happened to finish before Redash
+  // serialized it, its result can contain the complete schema; select and page
+  // that array instead of assembling it into the job object.
+  let documentDepth = 0;
+  let awaitingJobValue = false;
+  let jobAssembler: Assembler<Record<string, unknown>> | undefined;
+  let skippedJobResultDepth = 0;
+  let jobResponse: RedashSchemaJobResponse | undefined;
+
+  function observeResponseToken(token: Token): Token {
+    if (jobAssembler !== undefined) {
+      if (skippedJobResultDepth > 0) {
+        if (token.name === 'startObject' || token.name === 'startArray') {
+          skippedJobResultDepth += 1;
+        } else if (token.name === 'endObject' || token.name === 'endArray') {
+          skippedJobResultDepth -= 1;
+        }
+      } else if (
+        token.name === 'startArray'
+        && jobAssembler.depth === 1
+        && (jobAssembler.key === 'result' || jobAssembler.key === 'query_result_id')
+      ) {
+        // Redash serializes the completed schema under both result and the
+        // legacy query_result_id field. Keep metadata assembly bounded and let
+        // the page selector below consume job.result.
+        jobAssembler.consume({ name: 'nullValue', value: null });
+        skippedJobResultDepth = 1;
+      } else {
+        jobAssembler.consume(token);
+        if (jobAssembler.done) {
+          const job = jobAssembler.current;
+          if (typeof job !== 'object' || job === null || Array.isArray(job)) {
+            throw new Error('Redash schema response contained an invalid "job" object');
+          }
+          jobResponse = { job };
+          jobAssembler = undefined;
+        }
+      }
+    } else if (awaitingJobValue) {
+      awaitingJobValue = false;
+      if (token.name !== 'startObject') {
+        throw new Error('Redash schema response contained an invalid "job" object');
+      }
+      jobAssembler = new Assembler<Record<string, unknown>>();
+      jobAssembler.consume(token);
+    } else if (documentDepth === 1 && token.name === 'keyValue' && token.value === 'job') {
+      awaitingJobValue = true;
+    }
+
+    if (token.name === 'startObject' || token.name === 'startArray') {
+      documentDepth += 1;
+    } else if (token.name === 'endObject' || token.name === 'endArray') {
+      documentDepth -= 1;
+    }
+
+    return token;
+  }
+
+  // Distinguishes a valid empty schema array from an unrelated error payload.
+  // job.result is selected too because a very fast refresh can finish before
+  // the initial schema response is serialized.
+  let sawSchemaArray = false;
+
+  const pipeline = chain([
+    source,
+    // streamArray's assembler only reads packed values (keyValue/stringValue),
+    // so the chunk-wise value tokens would be generated only to be discarded.
+    parser({ streamValues: false }),
+    observeResponseToken,
+    pick({
+      filter: (stack, token) => token.name === 'startArray' && (
+        (stack.length === 1 && stack[0] === 'schema')
+        || (stack.length === 2 && stack[0] === 'job' && stack[1] === 'result')
+      ),
+    }),
+    (token: Token) => {
+      sawSchemaArray = true;
+      return token;
+    },
+    streamArray(),
+  ]);
+
+  // The axios timeout only covers time-to-first-response for streamed bodies,
+  // so consumption needs its own deadline.
+  const deadline = setTimeout(() => {
+    pipeline.destroy(new Error(
+      `Timed out reading schema response after ${deadlineMs}ms; raise REDASH_TIMEOUT for very large schemas`,
+    ));
+  }, deadlineMs);
+
+  const collected: SchemaTable[] = [];
+  let matched = 0;
+  let hasMore = false;
+  try {
+    for await (const entry of pipeline as AsyncIterable<{ key: number; value: unknown }>) {
+      const value = entry.value as SchemaTable;
+      if (searchLower !== undefined) {
+        const name = typeof value?.name === 'string' ? value.name : '';
+        if (!name.toLowerCase().includes(searchLower)) {
+          continue;
+        }
+      }
+      matched += 1;
+      if (matched <= offset) {
+        continue;
+      }
+      if (collected.length === pageSize) {
+        hasMore = true;
+        break;
+      }
+      collected.push(value);
+    }
+  } finally {
+    clearTimeout(deadline);
+    destroyQuietly(pipeline);
+    // stream-chain does not reliably propagate destroy back to its input, and
+    // destroying the source is what actually aborts the HTTP transfer.
+    destroyQuietly(source);
+  }
+
+  if (!sawSchemaArray) {
+    if (jobResponse !== undefined) {
+      return jobResponse;
+    }
+    throw new Error('Redash schema response did not contain a "schema" array');
+  }
+
+  return {
+    page,
+    pageSize,
+    hasMore,
+    nextPage: hasMore ? page + 1 : null,
+    schema: collected,
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import type { Readable } from 'node:stream';
+
 export function formatError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
@@ -8,6 +10,14 @@ export function isPlainObject(value: unknown): value is Record<string, unknown> 
 
 export function cloneValue<T>(value: T): T {
   return structuredClone(value);
+}
+
+// Destroys a stream that will no longer be consumed. The no-op error handler
+// must be attached first: late socket errors (ECONNRESET, premature close)
+// emitted after we stop consuming must not crash the process.
+export function destroyQuietly(stream: Readable): void {
+  stream.on('error', () => {});
+  stream.destroy();
 }
 
 export function mergeDeep<T extends Record<string, unknown>>(base: T, patch: Record<string, unknown>): T {


### PR DESCRIPTION
A large BigQuery data source can make Redash return hundreds of megabytes from `/api/data_sources/{id}/schema`. Axios buffered that response as a string and then parsed the full object, so the buffer and parsed schema could exhaust the default Node heap before `get_schema` returned anything.

`get_schema` now accepts `page`, `pageSize`, and an optional table-name `search`. It returns one page with `hasMore` and `nextPage`. For BigQuery, a configured location lets the server query that region's `INFORMATION_SCHEMA` for the requested tables. If the location is unavailable or the metadata query fails, the Redash schema response is parsed as a stream and the transfer stops after the requested page plus one matching table.

Pending Redash schema jobs still pass through unchanged. Query Results data sources return guidance to use `execute_adhoc_query` with `query_<id>` or `cached_query_<id>` instead.

The MCP response changes from the complete schema dump to a page object. `RedashClient.getSchema` remains available so removing that API stays an explicit compatibility decision.

This PR is stacked on #78, which establishes the Node 22 and pnpm 11 toolchain used here. #78 contains no schema changes and can be reviewed and merged independently.