### PR TITLE
fix: send visualization_id as null for text widgets (fixes #99)

### DIFF
--- a/src/__tests__/redashClient.test.ts
+++ b/src/__tests__/redashClient.test.ts
@@ -1522,6 +1522,22 @@ describe('RedashClient', () => {
       expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/widgets', widgetData);
       expect(result).toEqual(mockResponse.data);
     });
+
+    it('should send visualization_id as null for text widgets instead of omitting the key', async () => {
+      // Redash's widgets.py does widget_properties.pop("visualization_id") with no default,
+      // so an omitted key raises a server-side KeyError (HTTP 500) instead of the null branch.
+      const widgetData = { dashboard_id: 1, text: 'Some text', width: 3 };
+      const mockResponse = { data: { id: 2, ...widgetData, visualization_id: null } };
+      mockAxiosInstance.post.mockResolvedValue(mockResponse);
+
+      const result = await client.createWidget(widgetData);
+
+      expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/widgets', {
+        ...widgetData,
+        visualization_id: null,
+      });
+      expect(result).toEqual(mockResponse.data);
+    });
   });
 
   describe('updateWidget', () => {

--- a/src/redashClient.ts
+++ b/src/redashClient.ts
@@ -1365,7 +1365,10 @@ export class RedashClient {
   // Create a new widget
   async createWidget(data: CreateWidgetRequest): Promise<RedashWidget> {
     try {
-      const response = await this.client.post('/api/widgets', data);
+      // Redash's widgets.py does widget_properties.pop("visualization_id") with no default,
+      // so an omitted key (JSON.stringify drops undefined) raises a server-side 500 for text widgets.
+      const payload = { ...data, visualization_id: data.visualization_id ?? null };
+      const response = await this.client.post('/api/widgets', payload);
       return response.data;
     } catch (error) {
       logger.error(`Error creating widget: ${error}`);


### PR DESCRIPTION
## Problem

Fixes #99.

`create_widget` returns an HTTP 500 from Redash for text-only widgets (no `visualization_id`). Widget creation with a `visualization_id` present works fine.

## Root cause

`RedashClient.createWidget()` forwarded `visualization_id: params.visualization_id` straight to `axios.post('/api/widgets', data)`. For a text widget that value is `undefined`, and axios's default JSON serialization (`JSON.stringify`) drops keys with an `undefined` value — so the outgoing body has no `visualization_id` key at all.

Redash's server handler (`redash/handlers/widgets.py`) does:

```python
widget_properties.pop("id", None)                              # has a default
visualization_id = widget_properties.pop("visualization_id")   # no default -> KeyError if missing
```

A missing key raises an unhandled `KeyError`, surfaced by Flask as a 500. See #99 for the full trace.

## Fix

Send `visualization_id` explicitly as `null` instead of omitting it, at the API boundary in `RedashClient.createWidget()`:

```ts
const payload = { ...data, visualization_id: data.visualization_id ?? null };
```

This preserves the key through serialization so Redash's `.pop("visualization_id")` succeeds and takes the existing `else: visualization = None` branch.

## Testing

- Added a regression test in `src/__tests__/redashClient.test.ts` asserting the POST body includes `visualization_id: null` for a text-only widget (verified it fails without the fix, passes with it).
- Existing `createWidget` test (visualization widget) still passes unchanged — `?? null` is a no-op when the value is already defined.
- Full suite: `pnpm test` → 249/249 passing.
- `tsc --noEmit` clean.
